### PR TITLE
Adds `Model.all_released_ids_for`

### DIFF
--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -8,31 +8,43 @@ module FeatureFlagger
   # Account.first.rollout?([:email_marketing, :new_awesome_feature])
   # #=> true
   module Model
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
     def rollout?(feature_key)
-      Feature.new(feature_key, rollout_resource_name).fetch!
-      Control.rollout?(feature_key, id, rollout_resource_name)
+      resource_name = self.class.rollout_resource_name
+      Feature.new(feature_key, resource_name).fetch!
+      Control.rollout?(feature_key, id, resource_name)
     end
 
     def release!(feature_key)
-      Feature.new(feature_key, rollout_resource_name).fetch!
-      Control.release!(feature_key, id, rollout_resource_name)
+      resource_name = self.class.rollout_resource_name
+      Feature.new(feature_key, resource_name).fetch!
+      Control.release!(feature_key, id, resource_name)
     end
 
     def unrelease!(feature_key)
-      Feature.new(feature_key, rollout_resource_name).fetch!
-      Control.unrelease!(feature_key, id, rollout_resource_name)
+      resource_name = self.class.rollout_resource_name
+      Feature.new(feature_key, resource_name).fetch!
+      Control.unrelease!(feature_key, id, resource_name)
     end
 
-    private
+    module ClassMethods
+      def all_released_ids_for(feature_key)
+        Feature.new(feature_key, rollout_resource_name).fetch!
+        Control.resource_ids(feature_key, rollout_resource_name)
+      end
 
-    def rollout_resource_name
-      klass_name = self.class.name
-      klass_name.gsub!(/::/, '_')
-      klass_name.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
-      klass_name.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
-      klass_name.tr!("-", "_")
-      klass_name.downcase!
-      klass_name
+      def rollout_resource_name
+        klass_name = self.to_s
+        klass_name.gsub!(/::/, '_')
+        klass_name.gsub!(/([A-Z\d]+)([A-Z][a-z])/,'\1_\2')
+        klass_name.gsub!(/([a-z\d])([A-Z])/,'\1_\2')
+        klass_name.tr!("-", "_")
+        klass_name.downcase!
+        klass_name
+      end
     end
   end
 end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -37,5 +37,12 @@ module FeatureFlagger
         subject.unrelease!(key)
       end
     end
+
+    describe '.all_released_ids_for' do
+      it 'calls Control#resource_ids with appropriated methods' do
+        expect(Control).to receive(:resource_ids).with(key, 'feature_flagger_dummy_class')
+        DummyClass.all_released_ids_for(key)
+      end
+    end
   end
 end


### PR DESCRIPTION
So now is possible to fetch all resource_ids for a given model

Example:

``` ruby
class User < ActiveRecord::Base
  include FeatureFlagger::Model
end

User.all_released_ids_for([:email_marketing, :new_email_flow])
=> ["6", "48", "69"]
```
