### PR TITLE
Refactors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FeatureFlagger
 
-Partial release your features.
+Partially release your features.
 
 ## Installation
 
@@ -21,10 +21,17 @@ Or install it yourself as:
 
 ## Configuration
 
-1. Configure redis by adding `config/initializers/feature_flagger.rb`:
+By default, feature_flagger uses the REDIS_URL env var to setup it's storage.
+You can configure this by using `configure` like such:
+
+1. In a initializer file (e.g. `config/initializers/feature_flagger.rb`):
 ```ruby
+require 'redis-namespace'
+require 'feature_flagger'
+
 FeatureFlagger.configure do |config|
-  config.storage.redis = $redis
+  namespaced = ::Redis::Namespace.new("feature_flagger", redis: $redis)
+  config.storage = FeatureFlagger::Storage::Redis.new(namespaced)
 end
 ```
 

--- a/feature_flagger.gemspec
+++ b/feature_flagger.gemspec
@@ -14,13 +14,13 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Management tool to make it easier rollouting features to customers.}
   spec.homepage      = "http://github.com/ResultadosDigitais/feature_flagger"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = Dir['README.md', 'MIT-LICENSE', 'lib/**/*']
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'redis-namespace'
+  spec.add_dependency 'redis', '~> 3.2'
+  spec.add_dependency 'redis-namespace', '~> 1.3'
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "fakeredis"
 end

--- a/lib/feature_flagger.rb
+++ b/lib/feature_flagger.rb
@@ -1,5 +1,4 @@
 require 'yaml'
-require 'redis-namespace'
 
 require 'feature_flagger/version'
 require 'feature_flagger/storage/redis'
@@ -37,7 +36,7 @@ module FeatureFlagger
 
     def set_config
       @@config ||= {}
-      @@config[:storage] ||= Storage::Redis.new
+      @@config[:storage] ||= default_client
 
       # TODO: Provide a Rake to generate initial YAML file
       # for new projects.
@@ -49,6 +48,10 @@ module FeatureFlagger
       if file_path = @@config[:yaml_filepath]
         @@config[:info] ||= YAML.load_file(file_path)
       end
+    end
+
+    def default_client
+      Storage::Redis.default_client
     end
   end
 end

--- a/lib/feature_flagger/storage/redis.rb
+++ b/lib/feature_flagger/storage/redis.rb
@@ -1,31 +1,36 @@
+require 'redis'
+require 'redis-namespace'
+
 module FeatureFlagger
   module Storage
     class Redis
+
       DEFAULT_NAMESPACE = :feature_flagger
 
-      attr_writer :redis
+      def initialize(redis)
+        @redis = redis
+      end
 
-      def redis
-        @redis ||= begin
-          client = ::Redis.new(url: ENV['REDIS_URL'])
-          ::Redis::Namespace.new(DEFAULT_NAMESPACE, redis: client)
-        end
+      def self.default_client
+        redis = ::Redis.new(url: ENV['REDIS_URL'])
+        ns = ::Redis::Namespace.new(DEFAULT_NAMESPACE, :redis => redis)
+        new(ns)
       end
 
       def has_value?(key, value)
-        redis.sismember(key, value)
+        @redis.sismember(key, value)
       end
 
       def add(key, value)
-        redis.sadd(key, value)
+        @redis.sadd(key, value)
       end
 
       def remove(key, value)
-        redis.srem(key, value)
+        @redis.srem(key, value)
       end
 
       def all_values(key)
-        redis.smembers(key)
+        @redis.smembers(key)
       end
     end
   end

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 module FeatureFlagger
   RSpec.describe Control do
-    let(:storage) { Storage::Redis.new }
+    let(:redis) { FakeRedis::Redis.new }
+    let(:storage) { Storage::Redis.new(redis) }
     let(:control) { Control.new(storage) }
 
     before do
-      storage.redis = Redis.new(url: ENV['REDIS_URL'])
-      storage.redis.flushdb
+      redis.flushdb
     end
 
     describe '.rollout?' do
@@ -35,7 +35,7 @@ module FeatureFlagger
           control.release!([:email_marketing, :whitelabel], 15)
         end
 
-        it { is_expected.to eq %w{1 2 15} }
+        it { is_expected.to match_array %w{1 2 15} }
       end
 
       context 'when resource_name is passed' do
@@ -47,7 +47,7 @@ module FeatureFlagger
           control.release!('account:email_marketing:whitelabel', 50)
         end
 
-        it { is_expected.to eq %w{ 30 40 50 } }
+        it { is_expected.to match_array %w{ 30 40 50 } }
       end
     end
   end

--- a/spec/feature_flagger/storage/redis_spec.rb
+++ b/spec/feature_flagger/storage/redis_spec.rb
@@ -1,46 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe FeatureFlagger::Storage::Redis do
-  let(:redis)   { Redis.new(url: ENV['REDIS_URL']) }
-  let(:storage) { described_class.new }
+  let(:redis)   { FakeRedis::Redis.new }
+  let(:storage) { described_class.new(redis) }
   let(:key)   { 'foo' }
   let(:value) { 'bar' }
 
-  describe '#redis' do
-    context 'no redis client assigned' do
-      let(:host) { 'redishost' }
-      let(:port) { 1234 }
-      let(:url)  { "redis://#{host}:#{port}" }
-
-      around :each do |example|
-        storage.redis = nil
-        redis_url = ENV['REDIS_URL']
-        ENV['REDIS_URL'] = url
-        example.run
-        ENV['REDIS_URL'] = redis_url
-      end
-
-      it 'initializes a default redis namespace on REDIS_URL env' do
-        expect(storage.redis.namespace).to eq described_class::DEFAULT_NAMESPACE
-        expect(storage.redis.client.host).to eq host
-        expect(storage.redis.client.port).to eq port
-      end
-    end
-
-    context 'with redis assigned' do
-      before do
-        storage.redis = redis
-      end
-
-      it 'uses the given redis' do
-        expect(storage.redis).to eq redis
-      end
-    end
-  end
-
   context do
     before do
-      storage.redis = redis
       redis.flushdb
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'feature_flagger'
+require 'fakeredis'


### PR DESCRIPTION
Initially, I meant to remove redis-namespace but I gave it up.
It is a very small gem and probably wont cause any problems.
I took the opportunity to introduce some refactors.

Gains:

- got rid of git dep (easier to test on docker, http://www.codinginthecrease.com/news_article/show/350843?referrer_id=948927)
- FeatureFlagger has no knowledge of redis whatsoever
- Simplified Storage::Redis
- introduced fakeredis to facilitate testing (no dep on an actual Redis instance)