### PR TITLE
Better feature check syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,19 @@ end
 account = Account.first
 
 # Release feature for account
-account.release!([:email_marketing, :new_email_flow])
+account.release!(:email_marketing, :new_email_flow)
 #=> true
 
 # Check feature for a given account
-account.rollout?([:email_marketing, :new_email_flow])
+account.rollout?(:email_marketing, :new_email_flow)
 #=> true
 
 # Remove feature for given account
-account.unrelease!([:email_marketing, :new_email_flow])
+account.unrelease!(:email_marketing, :new_email_flow)
 #=> true
 
 # If you try to check an inexistent rollout key it will raise an error.
-account.rollout?([:email_marketing, :new_email_flo])
+account.rollout?(:email_marketing, :new_email_flow)
 FeatureFlagger::KeyNotFoundError: ["account", "email_marketing", "new_email_flo"]
 ```
 

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -6,32 +6,20 @@ module FeatureFlagger
       @storage = storage
     end
 
-    def rollout?(feature_key, resource_id, resource_name = nil)
-      feature_key = rsolv_key(feature_key, resource_name)
+    def rollout?(feature_key, resource_id)
       @storage.has_value?(feature_key, resource_id)
     end
 
-    def release!(feature_key, resource_id, resource_name = nil)
-      feature_key = rsolv_key(feature_key, resource_name)
+    def release!(feature_key, resource_id)
       @storage.add(feature_key, resource_id)
     end
 
-    def unrelease!(feature_key, resource_id, resource_name = nil)
-      feature_key = rsolv_key(feature_key, resource_name)
+    def unrelease!(feature_key, resource_id)
       @storage.remove(feature_key, resource_id)
     end
 
-    def resource_ids(feature_key, resource_name = nil)
-      feature_key = rsolv_key(feature_key, resource_name)
+    def resource_ids(feature_key)
       @storage.all_values(feature_key)
-    end
-
-    private
-
-    def rsolv_key(feature_key, resource_name = nil)
-      feature_key_arr = Array(feature_key)
-      feature_key_arr.insert(0, resource_name) unless resource_name.nil?
-      feature_key_arr.join(':')
     end
   end
 end

--- a/lib/feature_flagger/feature.rb
+++ b/lib/feature_flagger/feature.rb
@@ -1,29 +1,27 @@
 module FeatureFlagger
   class Feature
-
     def initialize(feature_key, resource_name = nil)
       @feature_key = resource_name.nil? ? feature_key : feature_key.clone.insert(0, resource_name)
       @feature_key = Array(@feature_key).collect(&:to_s)
       @doc = FeatureFlagger.config[:info]
-    end
-
-    def fetch!
-      @data ||= find_value(@doc, *@feature_key)
-      raise FeatureFlagger::KeyNotFoundError.new(@feature_key) if @data.nil?
-      @data
+      fetch_data
     end
 
     def description
-      fetch!
       @data['description']
     end
 
     def key
-      fetch!
       @feature_key.join(':')
     end
 
     private
+
+    def fetch_data
+      @data ||= find_value(@doc, *@feature_key)
+      raise FeatureFlagger::KeyNotFoundError.new(@feature_key) if @data.nil?
+      @data
+    end
 
     def find_value(hash, key, *tail)
       value = hash[key]
@@ -34,7 +32,6 @@ module FeatureFlagger
         find_value(value, *tail)
       end
     end
-
   end
 end
 

--- a/lib/feature_flagger/feature.rb
+++ b/lib/feature_flagger/feature.rb
@@ -1,8 +1,7 @@
 module FeatureFlagger
   class Feature
     def initialize(feature_key, resource_name = nil)
-      @feature_key = resource_name.nil? ? feature_key : feature_key.clone.insert(0, resource_name)
-      @feature_key = Array(@feature_key).collect(&:to_s)
+      @feature_key = resolve_key(feature_key, resource_name)
       @doc = FeatureFlagger.config[:info]
       fetch_data
     end
@@ -16,6 +15,12 @@ module FeatureFlagger
     end
 
     private
+
+    def resolve_key(feature_key, resource_name)
+      key = Array(feature_key).flatten
+      key.insert(0, resource_name) if resource_name
+      key.map(&:to_s)
+    end
 
     def fetch_data
       @data ||= find_value(@doc, *@feature_key)

--- a/lib/feature_flagger/feature.rb
+++ b/lib/feature_flagger/feature.rb
@@ -19,6 +19,7 @@ module FeatureFlagger
     end
 
     def key
+      fetch!
       @feature_key.join(':')
     end
 

--- a/lib/feature_flagger/feature.rb
+++ b/lib/feature_flagger/feature.rb
@@ -1,21 +1,25 @@
 module FeatureFlagger
   class Feature
 
-    def initialize(key, resource_name = nil)
-      @key = resource_name.nil? ? key : key.clone.insert(0, resource_name)
-      @key = Array(@key).collect(&:to_s)
+    def initialize(feature_key, resource_name = nil)
+      @feature_key = resource_name.nil? ? feature_key : feature_key.clone.insert(0, resource_name)
+      @feature_key = Array(@feature_key).collect(&:to_s)
       @doc = FeatureFlagger.config[:info]
     end
 
     def fetch!
-      @data ||= find_value(@doc, *@key)
-      raise FeatureFlagger::KeyNotFoundError.new(@key) if @data.nil?
+      @data ||= find_value(@doc, *@feature_key)
+      raise FeatureFlagger::KeyNotFoundError.new(@feature_key) if @data.nil?
       @data
     end
 
     def description
       fetch!
       @data['description']
+    end
+
+    def key
+      @feature_key.join(':')
     end
 
     private

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -15,29 +15,29 @@ module FeatureFlagger
     def rollout?(*feature_key)
       feature_key.flatten!
       resource_name = self.class.rollout_resource_name
-      Feature.new(feature_key, resource_name).fetch!
-      FeatureFlagger.control.rollout?(feature_key, id, resource_name)
+      feature = Feature.new(feature_key, resource_name)
+      FeatureFlagger.control.rollout?(feature.key, id)
     end
 
     def release!(*feature_key)
       feature_key.flatten!
       resource_name = self.class.rollout_resource_name
-      Feature.new(feature_key, resource_name).fetch!
-      FeatureFlagger.control.release!(feature_key, id, resource_name)
+      feature = Feature.new(feature_key, resource_name)
+      FeatureFlagger.control.release!(feature.key, id)
     end
 
     def unrelease!(*feature_key)
       feature_key.flatten!
       resource_name = self.class.rollout_resource_name
-      Feature.new(feature_key, resource_name).fetch!
-      FeatureFlagger.control.unrelease!(feature_key, id, resource_name)
+      feature = Feature.new(feature_key, resource_name)
+      FeatureFlagger.control.unrelease!(feature.key, id)
     end
 
     module ClassMethods
       def all_released_ids_for(*feature_key)
         feature_key.flatten!
-        Feature.new(feature_key, rollout_resource_name).fetch!
-        Control.resource_ids(feature_key, rollout_resource_name)
+        feature = Feature.new(feature_key, rollout_resource_name)
+        Control.resource_ids(feature.key)
       end
 
       def rollout_resource_name

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -13,21 +13,18 @@ module FeatureFlagger
     end
 
     def rollout?(*feature_key)
-      feature_key.flatten!
       resource_name = self.class.rollout_resource_name
       feature = Feature.new(feature_key, resource_name)
       FeatureFlagger.control.rollout?(feature.key, id)
     end
 
     def release!(*feature_key)
-      feature_key.flatten!
       resource_name = self.class.rollout_resource_name
       feature = Feature.new(feature_key, resource_name)
       FeatureFlagger.control.release!(feature.key, id)
     end
 
     def unrelease!(*feature_key)
-      feature_key.flatten!
       resource_name = self.class.rollout_resource_name
       feature = Feature.new(feature_key, resource_name)
       FeatureFlagger.control.unrelease!(feature.key, id)

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -12,26 +12,30 @@ module FeatureFlagger
       base.extend ClassMethods
     end
 
-    def rollout?(feature_key)
+    def rollout?(*feature_key)
+      feature_key.flatten!
       resource_name = self.class.rollout_resource_name
       Feature.new(feature_key, resource_name).fetch!
       FeatureFlagger.control.rollout?(feature_key, id, resource_name)
     end
 
-    def release!(feature_key)
+    def release!(*feature_key)
+      feature_key.flatten!
       resource_name = self.class.rollout_resource_name
       Feature.new(feature_key, resource_name).fetch!
       FeatureFlagger.control.release!(feature_key, id, resource_name)
     end
 
-    def unrelease!(feature_key)
+    def unrelease!(*feature_key)
+      feature_key.flatten!
       resource_name = self.class.rollout_resource_name
       Feature.new(feature_key, resource_name).fetch!
       FeatureFlagger.control.unrelease!(feature_key, id, resource_name)
     end
 
     module ClassMethods
-      def all_released_ids_for(feature_key)
+      def all_released_ids_for(*feature_key)
+        feature_key.flatten!
         Feature.new(feature_key, rollout_resource_name).fetch!
         Control.resource_ids(feature_key, rollout_resource_name)
       end

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -5,49 +5,49 @@ module FeatureFlagger
     let(:redis) { FakeRedis::Redis.new }
     let(:storage) { Storage::Redis.new(redis) }
     let(:control) { Control.new(storage) }
+    let(:key)         { 'key' }
+    let(:resource_id) { 'resource_id' }
 
     before do
       redis.flushdb
     end
 
-    describe '.rollout?' do
-      let(:result) { control.rollout?([:email_marketing, :new_flow], 'resource_id') }
+    describe '#rollout?' do
+      let(:result) { control.rollout?(key, resource_id) }
 
       context 'when resource entity id has no access to release_key' do
         it { expect(result).to be_falsey }
       end
 
       context 'when resource entity id has access to release_key' do
-        before { control.release!([:email_marketing, :new_flow], 'resource_id') }
+        before { storage.add(key, resource_id) }
         it { expect(result).to be_truthy }
       end
     end
 
-    describe '.release!'
-    describe '.unrelease!'
-    describe '.resource_ids' do
-      context 'when resource_name is nil' do
-        subject { control.resource_ids([:email_marketing, :whitelabel]) }
-
-        before do
-          control.release!([:email_marketing, :whitelabel], 1)
-          control.release!([:email_marketing, :whitelabel], 2)
-          control.release!([:email_marketing, :whitelabel], 15)
-        end
-
-        it { is_expected.to match_array %w{1 2 15} }
+    describe '#release!' do
+      it 'adds resource_id to storage' do
+        control.release!(key, resource_id)
+        expect(storage).to have_value(key, resource_id)
       end
+    end
 
-      context 'when resource_name is passed' do
-        subject { control.resource_ids([:email_marketing, :whitelabel], :account) }
+    describe '#unrelease!' do
+      it 'removes resource_id from storage' do
+        storage.add(key, resource_id)
+        control.unrelease!(key, resource_id)
+        expect(storage).not_to have_value(key, resource_id)
+      end
+    end
 
-        before do
-          control.release!('account:email_marketing:whitelabel', 30)
-          control.release!('account:email_marketing:whitelabel', 40)
-          control.release!('account:email_marketing:whitelabel', 50)
-        end
+    describe '#resource_ids' do
+      subject { control.resource_ids(key) }
 
-        it { is_expected.to match_array %w{ 30 40 50 } }
+      it 'returns all the values to given key' do
+        control.release!(key, 1)
+        control.release!(key, 2)
+        control.release!(key, 15)
+        is_expected.to match_array %w(1 2 15)
       end
     end
   end

--- a/spec/feature_flagger/feature_spec.rb
+++ b/spec/feature_flagger/feature_spec.rb
@@ -20,6 +20,14 @@ module FeatureFlagger
         let(:key) { [:email_marketing, :new_email_flow] }
         it { expect { subject }.to raise_error(FeatureFlagger::KeyNotFoundError) }
       end
+
+      context 'with key argument as an array of arrays' do
+        let(:key)          { [[:email_marketing, :behavior_score]] }
+        let(:resolved_key) { 'feature_flagger_dummy_class:email_marketing:behavior_score' }
+        it 'flattens the array and acts as an unidimensional array' do
+          expect(subject.key).to eq resolved_key
+        end
+      end
     end
 
     describe '#description' do

--- a/spec/feature_flagger/feature_spec.rb
+++ b/spec/feature_flagger/feature_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 module FeatureFlagger
   RSpec.describe Feature do
+    subject { Feature.new(key, :feature_flagger_dummy_class) }
 
     before do
       filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
@@ -10,14 +11,23 @@ module FeatureFlagger
     end
 
     describe '#description' do
-      context 'when feature documented' do
-        subject { Feature.new([:email_marketing, :behavior_score], :feature_flagger_dummy_class) }
+      context 'when feature is documented' do
+        let(:key) { [:email_marketing, :behavior_score] }
         it { expect(subject.description).to eq 'Enable behavior score experiment' }
       end
 
       context 'when feature is not documented' do
-        subject { Feature.new([:email_marketing, :new_email_flow], :feature_flagger_dummy_class) }
+        let(:key) { [:email_marketing, :new_email_flow] }
         it { expect { subject.description }.to raise_error(FeatureFlagger::KeyNotFoundError) }
+      end
+    end
+
+    describe '#key' do
+      let(:key)          { [:email_marketing, :behavior_score] }
+      let(:resolved_key) { 'feature_flagger_dummy_class:email_marketing:behavior_score' }
+
+      it 'returns the given key resolved and joined with resource_name' do
+        expect(subject.key).to eq resolved_key
       end
     end
   end

--- a/spec/feature_flagger/feature_spec.rb
+++ b/spec/feature_flagger/feature_spec.rb
@@ -10,16 +10,21 @@ module FeatureFlagger
       allow(FeatureFlagger).to receive(:config).and_return(info: info)
     end
 
-    describe '#description' do
+    describe '#initialize' do
       context 'when feature is documented' do
         let(:key) { [:email_marketing, :behavior_score] }
-        it { expect(subject.description).to eq 'Enable behavior score experiment' }
+        it { expect(subject).to be_a Feature }
       end
 
       context 'when feature is not documented' do
         let(:key) { [:email_marketing, :new_email_flow] }
-        it { expect { subject.description }.to raise_error(FeatureFlagger::KeyNotFoundError) }
+        it { expect { subject }.to raise_error(FeatureFlagger::KeyNotFoundError) }
       end
+    end
+
+    describe '#description' do
+      let(:key) { [:email_marketing, :behavior_score] }
+      it { expect(subject.description).to eq 'Enable behavior score experiment' }
     end
 
     describe '#key' do

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -19,30 +19,66 @@ module FeatureFlagger
     end
 
     describe '#release!' do
-      it 'calls Control#release! with appropriated methods' do
-        expect(control).to receive(:release!).with(key, subject.id, 'feature_flagger_dummy_class')
-        subject.release!(key)
+      context 'with key as multiple arguments' do
+        it 'calls Control#release! with appropriated methods' do
+          expect(control).to receive(:release!).with(key, subject.id, 'feature_flagger_dummy_class')
+          subject.release!(*key)
+        end
+      end
+
+      context 'with key argument as an array' do
+        it 'calls Control#release! with appropriated methods' do
+          expect(control).to receive(:release!).with(key, subject.id, 'feature_flagger_dummy_class')
+          subject.release!(key)
+        end
       end
     end
 
     describe '#rollout?' do
-      it 'calls Control#rollout? with appropriated methods' do
-        expect(control).to receive(:rollout?).with(key, subject.id, 'feature_flagger_dummy_class')
-        subject.rollout?(key)
+      context 'with key as multiple arguments' do
+        it 'calls Control#rollout? with appropriated methods' do
+          expect(control).to receive(:rollout?).with(key, subject.id, 'feature_flagger_dummy_class')
+          subject.rollout?(*key)
+        end
+      end
+
+      context 'with key argument as an array' do
+        it 'calls Control#rollout? with appropriated methods' do
+          expect(control).to receive(:rollout?).with(key, subject.id, 'feature_flagger_dummy_class')
+          subject.rollout?(key)
+        end
       end
     end
 
     describe '#unrelease!' do
-      it 'calls Control#unrelease! with appropriated methods' do
-        expect(control).to receive(:unrelease!).with(key, subject.id, 'feature_flagger_dummy_class')
-        subject.unrelease!(key)
+      context 'with key as multiple arguments' do
+        it 'calls Control#unrelease! with appropriated methods' do
+          expect(control).to receive(:unrelease!).with(key, subject.id, 'feature_flagger_dummy_class')
+          subject.unrelease!(*key)
+        end
+      end
+
+      context 'with key argument as an array' do
+        it 'calls Control#unrelease! with appropriated methods' do
+          expect(control).to receive(:unrelease!).with(key, subject.id, 'feature_flagger_dummy_class')
+          subject.unrelease!(key)
+        end
       end
     end
 
     describe '.all_released_ids_for' do
-      it 'calls Control#resource_ids with appropriated methods' do
-        expect(Control).to receive(:resource_ids).with(key, 'feature_flagger_dummy_class')
-        DummyClass.all_released_ids_for(key)
+      context 'with key as multiple arguments' do
+        it 'calls Control#resource_ids with appropriated methods' do
+          expect(Control).to receive(:resource_ids).with(key, 'feature_flagger_dummy_class')
+          DummyClass.all_released_ids_for(*key)
+        end
+      end
+
+      context 'with key argument as an array' do
+        it 'calls Control#resource_ids with appropriated methods' do
+          expect(Control).to receive(:resource_ids).with(key, 'feature_flagger_dummy_class')
+          DummyClass.all_released_ids_for(key)
+        end
       end
     end
   end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -20,66 +20,30 @@ module FeatureFlagger
     end
 
     describe '#release!' do
-      context 'with key as multiple arguments' do
-        it 'calls Control#release! with appropriated methods' do
-          expect(control).to receive(:release!).with(resolved_key, subject.id)
-          subject.release!(*key)
-        end
-      end
-
-      context 'with key argument as an array' do
-        it 'calls Control#release! with appropriated methods' do
-          expect(control).to receive(:release!).with(resolved_key, subject.id)
-          subject.release!(key)
-        end
+      it 'calls Control#release! with appropriated methods' do
+        expect(control).to receive(:release!).with(resolved_key, subject.id)
+        subject.release!(key)
       end
     end
 
     describe '#rollout?' do
-      context 'with key as multiple arguments' do
-        it 'calls Control#rollout? with appropriated methods' do
-          expect(control).to receive(:rollout?).with(resolved_key, subject.id)
-          subject.rollout?(*key)
-        end
-      end
-
-      context 'with key argument as an array' do
-        it 'calls Control#rollout? with appropriated methods' do
-          expect(control).to receive(:rollout?).with(resolved_key, subject.id)
-          subject.rollout?(key)
-        end
+      it 'calls Control#rollout? with appropriated methods' do
+        expect(control).to receive(:rollout?).with(resolved_key, subject.id)
+        subject.rollout?(key)
       end
     end
 
     describe '#unrelease!' do
-      context 'with key as multiple arguments' do
-        it 'calls Control#unrelease! with appropriated methods' do
-          expect(control).to receive(:unrelease!).with(resolved_key, subject.id)
-          subject.unrelease!(*key)
-        end
-      end
-
-      context 'with key argument as an array' do
-        it 'calls Control#unrelease! with appropriated methods' do
-          expect(control).to receive(:unrelease!).with(resolved_key, subject.id)
-          subject.unrelease!(key)
-        end
+      it 'calls Control#unrelease! with appropriated methods' do
+        expect(control).to receive(:unrelease!).with(resolved_key, subject.id)
+        subject.unrelease!(key)
       end
     end
 
     describe '.all_released_ids_for' do
-      context 'with key as multiple arguments' do
-        it 'calls Control#resource_ids with appropriated methods' do
-          expect(Control).to receive(:resource_ids).with(resolved_key)
-          DummyClass.all_released_ids_for(*key)
-        end
-      end
-
-      context 'with key argument as an array' do
-        it 'calls Control#resource_ids with appropriated methods' do
-          expect(Control).to receive(:resource_ids).with(resolved_key)
-          DummyClass.all_released_ids_for(key)
-        end
+      it 'calls Control#resource_ids with appropriated methods' do
+        expect(Control).to receive(:resource_ids).with(resolved_key)
+        DummyClass.all_released_ids_for(key)
       end
     end
   end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -8,9 +8,10 @@ module FeatureFlagger
   end
 
   RSpec.describe Model do
-    subject       { DummyClass.new }
-    let(:key)     { [:email_marketing, :whitelabel] }
-    let(:control) { FeatureFlagger.control }
+    subject             { DummyClass.new }
+    let(:key)           { [:email_marketing, :whitelabel] }
+    let(:resolved_key)  { 'feature_flagger_dummy_class:email_marketing:whitelabel' }
+    let(:control)       { FeatureFlagger.control }
 
     before do
       filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
@@ -21,14 +22,14 @@ module FeatureFlagger
     describe '#release!' do
       context 'with key as multiple arguments' do
         it 'calls Control#release! with appropriated methods' do
-          expect(control).to receive(:release!).with(key, subject.id, 'feature_flagger_dummy_class')
+          expect(control).to receive(:release!).with(resolved_key, subject.id)
           subject.release!(*key)
         end
       end
 
       context 'with key argument as an array' do
         it 'calls Control#release! with appropriated methods' do
-          expect(control).to receive(:release!).with(key, subject.id, 'feature_flagger_dummy_class')
+          expect(control).to receive(:release!).with(resolved_key, subject.id)
           subject.release!(key)
         end
       end
@@ -37,14 +38,14 @@ module FeatureFlagger
     describe '#rollout?' do
       context 'with key as multiple arguments' do
         it 'calls Control#rollout? with appropriated methods' do
-          expect(control).to receive(:rollout?).with(key, subject.id, 'feature_flagger_dummy_class')
+          expect(control).to receive(:rollout?).with(resolved_key, subject.id)
           subject.rollout?(*key)
         end
       end
 
       context 'with key argument as an array' do
         it 'calls Control#rollout? with appropriated methods' do
-          expect(control).to receive(:rollout?).with(key, subject.id, 'feature_flagger_dummy_class')
+          expect(control).to receive(:rollout?).with(resolved_key, subject.id)
           subject.rollout?(key)
         end
       end
@@ -53,14 +54,14 @@ module FeatureFlagger
     describe '#unrelease!' do
       context 'with key as multiple arguments' do
         it 'calls Control#unrelease! with appropriated methods' do
-          expect(control).to receive(:unrelease!).with(key, subject.id, 'feature_flagger_dummy_class')
+          expect(control).to receive(:unrelease!).with(resolved_key, subject.id)
           subject.unrelease!(*key)
         end
       end
 
       context 'with key argument as an array' do
         it 'calls Control#unrelease! with appropriated methods' do
-          expect(control).to receive(:unrelease!).with(key, subject.id, 'feature_flagger_dummy_class')
+          expect(control).to receive(:unrelease!).with(resolved_key, subject.id)
           subject.unrelease!(key)
         end
       end
@@ -69,14 +70,14 @@ module FeatureFlagger
     describe '.all_released_ids_for' do
       context 'with key as multiple arguments' do
         it 'calls Control#resource_ids with appropriated methods' do
-          expect(Control).to receive(:resource_ids).with(key, 'feature_flagger_dummy_class')
+          expect(Control).to receive(:resource_ids).with(resolved_key)
           DummyClass.all_released_ids_for(*key)
         end
       end
 
       context 'with key argument as an array' do
         it 'calls Control#resource_ids with appropriated methods' do
-          expect(Control).to receive(:resource_ids).with(key, 'feature_flagger_dummy_class')
+          expect(Control).to receive(:resource_ids).with(resolved_key)
           DummyClass.all_released_ids_for(key)
         end
       end


### PR DESCRIPTION
#15 

This PR makes the use of the array `[ ]` optional when checking for a feature. Example:

Instead of checking the feature as following:

```ruby
acount.rollout?([:email_marketing, :new_flow])
```

Now the following syntax is also accepted:

```ruby
acount.rollout?(:email_marketing, :new_flow)
```