### PR TITLE
Refactor code to get rid of bangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ end
 account = Account.first
 
 # Release feature for account
-account.release!(:email_marketing, :new_email_flow)
+account.release(:email_marketing, :new_email_flow)
 #=> true
 
 # Check feature for a given account
@@ -68,7 +68,7 @@ account.rollout?(:email_marketing, :new_email_flow)
 #=> true
 
 # Remove feature for given account
-account.unrelease!(:email_marketing, :new_email_flow)
+account.unrelease(:email_marketing, :new_email_flow)
 #=> true
 
 # If you try to check an inexistent rollout key it will raise an error.

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -10,12 +10,24 @@ module FeatureFlagger
       @storage.has_value?(feature_key, resource_id)
     end
 
-    def release!(feature_key, resource_id)
+    def release(feature_key, resource_id)
       @storage.add(feature_key, resource_id)
     end
 
-    def unrelease!(feature_key, resource_id)
+    # <b>DEPRECATED:</b> Please use <tt>release</tt> instead.
+    def release!(feature_key, resource_id)
+      warn "[DEPRECATION] `release!` is deprecated.  Please use `release` instead."
+      release(feature_key, resource_id)
+    end
+
+    def unrelease(feature_key, resource_id)
       @storage.remove(feature_key, resource_id)
+    end
+
+    # <b>DEPRECATED:</b> Please use <tt>unrelease</tt> instead.
+    def unrelease!(feature_key, resource_id)
+      warn "[DEPRECATION] `unrelease!` is deprecated.  Please use `unrelease` instead."
+      unrelease(feature_key, resource_id)
     end
 
     def resource_ids(feature_key)

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -18,16 +18,28 @@ module FeatureFlagger
       FeatureFlagger.control.rollout?(feature.key, id)
     end
 
+    # <b>DEPRECATED:</b> Please use <tt>release</tt> instead.
     def release!(*feature_key)
-      resource_name = self.class.rollout_resource_name
-      feature = Feature.new(feature_key, resource_name)
-      FeatureFlagger.control.release!(feature.key, id)
+      warn "[DEPRECATION] `release!` is deprecated.  Please use `release` instead."
+      release(*feature_key)
     end
 
-    def unrelease!(*feature_key)
+    def release(*feature_key)
       resource_name = self.class.rollout_resource_name
       feature = Feature.new(feature_key, resource_name)
-      FeatureFlagger.control.unrelease!(feature.key, id)
+      FeatureFlagger.control.release(feature.key, id)
+    end
+
+    # <b>DEPRECATED:</b> Please use <tt>unrelease</tt> instead.
+    def unrelease!(*feature_key)
+      warn "[DEPRECATION] `unrelease!` is deprecated.  Please use `unrelease` instead."
+      unrelease(*feature_key)
+    end
+
+    def unrelease(*feature_key)
+      resource_name = self.class.rollout_resource_name
+      feature = Feature.new(feature_key, resource_name)
+      FeatureFlagger.control.unrelease(feature.key, id)
     end
 
     module ClassMethods

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -25,17 +25,17 @@ module FeatureFlagger
       end
     end
 
-    describe '#release!' do
+    describe '#release' do
       it 'adds resource_id to storage' do
-        control.release!(key, resource_id)
+        control.release(key, resource_id)
         expect(storage).to have_value(key, resource_id)
       end
     end
 
-    describe '#unrelease!' do
+    describe '#unrelease' do
       it 'removes resource_id from storage' do
         storage.add(key, resource_id)
-        control.unrelease!(key, resource_id)
+        control.unrelease(key, resource_id)
         expect(storage).not_to have_value(key, resource_id)
       end
     end
@@ -44,9 +44,9 @@ module FeatureFlagger
       subject { control.resource_ids(key) }
 
       it 'returns all the values to given key' do
-        control.release!(key, 1)
-        control.release!(key, 2)
-        control.release!(key, 15)
+        control.release(key, 1)
+        control.release(key, 2)
+        control.release(key, 15)
         is_expected.to match_array %w(1 2 15)
       end
     end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -19,10 +19,10 @@ module FeatureFlagger
       allow(FeatureFlagger).to receive(:config).and_return(info: info)
     end
 
-    describe '#release!' do
-      it 'calls Control#release! with appropriated methods' do
-        expect(control).to receive(:release!).with(resolved_key, subject.id)
-        subject.release!(key)
+    describe '#release' do
+      it 'calls Control#release with appropriated methods' do
+        expect(control).to receive(:release).with(resolved_key, subject.id)
+        subject.release(key)
       end
     end
 
@@ -33,10 +33,10 @@ module FeatureFlagger
       end
     end
 
-    describe '#unrelease!' do
-      it 'calls Control#unrelease! with appropriated methods' do
-        expect(control).to receive(:unrelease!).with(resolved_key, subject.id)
-        subject.unrelease!(key)
+    describe '#unrelease' do
+      it 'calls Control#unrelease with appropriated methods' do
+        expect(control).to receive(:unrelease).with(resolved_key, subject.id)
+        subject.unrelease(key)
       end
     end
 


### PR DESCRIPTION
Bangs are a code smells known as [Prima Dona methods](https://github.com/troessner/reek/blob/master/docs/Prima-Donna-Method.md) when no "safe" option exists.
Added a deprecation warning for the bang methods, which we should remove on the next version bump.