### PR TITLE
Fix error on method to get all ids released by feature

### DIFF
--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -46,7 +46,7 @@ module FeatureFlagger
       def all_released_ids_for(*feature_key)
         feature_key.flatten!
         feature = Feature.new(feature_key, rollout_resource_name)
-        Control.resource_ids(feature.key)
+        FeatureFlagger.control.resource_ids(feature.key)
       end
 
       def rollout_resource_name

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -41,7 +41,7 @@ module FeatureFlagger
 
     describe '.all_released_ids_for' do
       it 'calls Control#resource_ids with appropriated methods' do
-        expect(Control).to receive(:resource_ids).with(resolved_key)
+        expect(control).to receive(:resource_ids).with(resolved_key)
         DummyClass.all_released_ids_for(key)
       end
     end


### PR DESCRIPTION
Fix this error: 

```ruby
irb(main):004:0> Account.all_released_ids_for(:customer_journey, :success_plans)
NoMethodError: undefined method `resource_ids' for FeatureFlagger::Control:Class

```