### PR TITLE
Remove explicit block parameter

### DIFF
--- a/lib/feature_flagger.rb
+++ b/lib/feature_flagger.rb
@@ -9,7 +9,7 @@ require 'feature_flagger/configuration'
 
 module FeatureFlagger
   class << self
-    def configure(&block)
+    def configure
       yield config if block_given?
     end
 


### PR DESCRIPTION
Besides correcting a Code Climate Issues, implicit block parameter is faster than explicit.

Source:
 - http://mudge.name/2011/01/26/passing-blocks-in-ruby-without-block.html
 - And Aaron Patterson Talk at Rubyconf: https://youtu.be/I8m6rY4JI1U?t=29m57s