### PR TITLE
Bug fix: allow FeatureFlagger.configure to be called more than once

### DIFF
--- a/lib/feature_flagger.rb
+++ b/lib/feature_flagger.rb
@@ -10,6 +10,8 @@ require 'feature_flagger/configuration'
 module FeatureFlagger
   class << self
     def configure
+      @@configuration = nil
+      @@control = nil
       yield config if block_given?
     end
 

--- a/lib/feature_flagger/version.rb
+++ b/lib/feature_flagger/version.rb
@@ -1,3 +1,3 @@
 module FeatureFlagger
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/spec/feature_flagger_spec.rb
+++ b/spec/feature_flagger_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 RSpec.describe FeatureFlagger do
   describe '.configure' do
-    let(:redis)   { double('redis') }
     let(:storage) { double('storage') }
+    let(:other_storage) { double('other_storage') }
 
     before do
       FeatureFlagger.configure do |config|
@@ -12,10 +12,25 @@ RSpec.describe FeatureFlagger do
     end
 
     it { expect(FeatureFlagger.config.storage).to eq storage }
+
+    it 'Calling configure with a new storage must change control.storage' do
+      FeatureFlagger.configure do |config|
+        config.storage = other_storage
+      end
+
+      expect(FeatureFlagger.config.storage).to eq other_storage
+      expect(FeatureFlagger.control.storage).to eq other_storage
+    end
   end
 
   describe '.control' do
     let(:control) { FeatureFlagger.control }
+
+    before do
+      FeatureFlagger.configure do |config|
+      end
+    end
+
     it 'initializes a Control with redis storage' do
       expect(control).to be_a(FeatureFlagger::Control)
       expect(control.storage).to be_a(FeatureFlagger::Storage::Redis)


### PR DESCRIPTION
Previously it was not possible to call FeatureFlagger.configure more than once to override the configuration since FeatureFlagger.control was memoizing storage information from the previous call. This PR make sure that whenever calling configure we start with a fresh configuration and control.