### PR TITLE
Rollout by resource id

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ account.unrelease(:email_marketing, :new_email_flow)
 account.rollout?(:email_marketing, :new_email_flow)
 FeatureFlagger::KeyNotFoundError: ["account", "email_marketing", "new_email_flo"]
 
+# Check feature for a specific account id
+Account.rollout_by_id?([:email_marketing, :new_email_flow], 42)
+#=> true
+
 # Get an array with all released Account ids
 Account.all_released_ids_for(:email_marketing, :new_email_flow)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ account.rollout?(:email_marketing, :new_email_flow)
 FeatureFlagger::KeyNotFoundError: ["account", "email_marketing", "new_email_flo"]
 
 # Check feature for a specific account id
-Account.rollout_by_id?([:email_marketing, :new_email_flow], 42)
+Account.released_id?(42, :email_marketing, :new_email_flow)
 #=> true
 
 # Get an array with all released Account ids

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -13,13 +13,7 @@ module FeatureFlagger
     end
 
     def rollout?(*feature_key)
-      rollout_by_id?(feature_key, id)
-    end
-
-    def rollout_by_id?(feature_key, resource_id)
-      resource_name = self.class.rollout_resource_name
-      feature = Feature.new(feature_key, resource_name)
-      FeatureFlagger.control.rollout?(feature.key, resource_id)
+      self.class.rollout_by_id?(feature_key, id)
     end
 
     # <b>DEPRECATED:</b> Please use <tt>release</tt> instead.
@@ -47,6 +41,12 @@ module FeatureFlagger
     end
 
     module ClassMethods
+      def rollout_by_id?(feature_key, resource_id)
+        resource_name = rollout_resource_name
+        feature = Feature.new(feature_key, resource_name)
+        FeatureFlagger.control.rollout?(feature.key, resource_id)
+      end
+
       def all_released_ids_for(*feature_key)
         feature_key.flatten!
         feature = Feature.new(feature_key, rollout_resource_name)

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -13,7 +13,7 @@ module FeatureFlagger
     end
 
     def rollout?(*feature_key)
-      self.class.rollout_by_id?(feature_key, id)
+      self.class.released_id?(id, feature_key)
     end
 
     # <b>DEPRECATED:</b> Please use <tt>release</tt> instead.
@@ -41,7 +41,7 @@ module FeatureFlagger
     end
 
     module ClassMethods
-      def rollout_by_id?(feature_key, resource_id)
+      def released_id?(resource_id, *feature_key)
         feature = Feature.new(feature_key, rollout_resource_name)
         FeatureFlagger.control.rollout?(feature.key, resource_id)
       end

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -42,8 +42,7 @@ module FeatureFlagger
 
     module ClassMethods
       def rollout_by_id?(feature_key, resource_id)
-        resource_name = rollout_resource_name
-        feature = Feature.new(feature_key, resource_name)
+        feature = Feature.new(feature_key, rollout_resource_name)
         FeatureFlagger.control.rollout?(feature.key, resource_id)
       end
 

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -13,9 +13,13 @@ module FeatureFlagger
     end
 
     def rollout?(*feature_key)
+      rollout_by_id?(feature_key, id)
+    end
+
+    def rollout_by_id?(feature_key, resource_id)
       resource_name = self.class.rollout_resource_name
       feature = Feature.new(feature_key, resource_name)
-      FeatureFlagger.control.rollout?(feature.key, id)
+      FeatureFlagger.control.rollout?(feature.key, resource_id)
     end
 
     # <b>DEPRECATED:</b> Please use <tt>release</tt> instead.

--- a/lib/feature_flagger/version.rb
+++ b/lib/feature_flagger/version.rb
@@ -1,3 +1,3 @@
 module FeatureFlagger
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -32,21 +32,22 @@ module FeatureFlagger
       end
     end
 
-    describe '#rollout_by_id?' do
-      context 'given a specific resource id' do
-        let(:resource_id) { 10 }
-
-        it 'calls Control#rollout? with appropriated methods' do
-          expect(control).to receive(:rollout?).with(resolved_key, resource_id)
-          subject.rollout_by_id?(key, resource_id)
-        end
-      end
-    end
 
     describe '#unrelease' do
       it 'calls Control#unrelease with appropriated methods' do
         expect(control).to receive(:unrelease).with(resolved_key, subject.id)
         subject.unrelease(key)
+      end
+    end
+
+    describe '.rollout_by_id?' do
+      context 'given a specific resource id' do
+        let(:resource_id) { 10 }
+
+        it 'calls Control#rollout? with appropriated methods' do
+          expect(control).to receive(:rollout?).with(resolved_key, resource_id)
+          DummyClass.rollout_by_id?(key, resource_id)
+        end
       end
     end
 

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -32,7 +32,6 @@ module FeatureFlagger
       end
     end
 
-
     describe '#unrelease' do
       it 'calls Control#unrelease with appropriated methods' do
         expect(control).to receive(:unrelease).with(resolved_key, subject.id)

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -39,13 +39,13 @@ module FeatureFlagger
       end
     end
 
-    describe '.rollout_by_id?' do
+    describe '.released_id?' do
       context 'given a specific resource id' do
         let(:resource_id) { 10 }
 
         it 'calls Control#rollout? with appropriated methods' do
           expect(control).to receive(:rollout?).with(resolved_key, resource_id)
-          DummyClass.rollout_by_id?(key, resource_id)
+          DummyClass.released_id?(resource_id, key)
         end
       end
     end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -32,6 +32,17 @@ module FeatureFlagger
       end
     end
 
+    describe '#rollout_by_id?' do
+      context 'given a specific resource id' do
+        let(:resource_id) { 10 }
+
+        it 'calls Control#rollout? with appropriated methods' do
+          expect(control).to receive(:rollout?).with(resolved_key, resource_id)
+          subject.rollout_by_id?(key, resource_id)
+        end
+      end
+    end
+
     describe '#unrelease' do
       it 'calls Control#unrelease with appropriated methods' do
         expect(control).to receive(:unrelease).with(resolved_key, subject.id)


### PR DESCRIPTION
Implemented a method to retrieve rollout info specifying the resource id, for scenarios where you don't want to build the model object just to check for a rollout.

Use:
```ruby
Account.rollout_by_id?([:email_marketing, :new_email_flow], 10)
```