### PR TITLE
Releases under a chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ account.rollout?(:email_marketing, :new_email_flow)
 account.unrelease(:email_marketing, :new_email_flow)
 #=> true
 
+# Return an array with all features released for given account under a chain
+account.released_features(:email_marketing)
+#=> ['account:email_marketing:new_email_flow', 'account:email_marketing:super_new_email_flow']
+
 # If you try to check an inexistent rollout key it will raise an error.
 account.rollout?(:email_marketing, :new_email_flow)
 FeatureFlagger::KeyNotFoundError: ["account", "email_marketing", "new_email_flo"]

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -13,8 +13,8 @@ module FeatureFlagger
     end
 
     def released_keys(feature_key, resource_id)
-      features = @storage.all_keys(feature_key)
-      features.map { @storage.has_value?(feature_key, resource_id) }
+      features = @storage.all_keys("#{feature_key}*")
+      features.select { |f| @storage.has_value?(f, resource_id) }
     end
 
     def release(feature_key, resource_id)

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -13,9 +13,13 @@ module FeatureFlagger
     end
 
     def released_features(features_keys, resource_id)
-      @storage.pipelined do
+      features_has_values = @storage.pipelined do
         features_keys.select { |f| @storage.has_value?(f, resource_id) }
       end
+      
+      released_features = Hash[features_keys.zip(features_has_values)]
+      released_features.select { |_, value| value }
+                       .collect { |key,_| key }
     end
 
     def release(feature_key, resource_id)

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -12,7 +12,7 @@ module FeatureFlagger
       @storage.has_value?(RELEASED_FEATURES, feature_key) || @storage.has_value?(feature_key, resource_id)
     end
 
-    def released_keys?(features_keys, resource_id)
+    def released_keys(features_keys, resource_id)
       @storage.pipelined do
         features_keys.select { |f| @storage.has_value?(f, resource_id) }
       end

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -12,9 +12,10 @@ module FeatureFlagger
       @storage.has_value?(RELEASED_FEATURES, feature_key) || @storage.has_value?(feature_key, resource_id)
     end
 
-    def released_keys(feature_key, resource_id)
-      features = @storage.all_keys("#{feature_key}*")
-      features.select { |f| @storage.has_value?(f, resource_id) }
+    def released_keys?(features_keys, resource_id)
+      @storage.pipelined do
+        features_keys.select { |f| @storage.has_value?(f, resource_id) }
+      end
     end
 
     def release(feature_key, resource_id)

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -12,7 +12,7 @@ module FeatureFlagger
       @storage.has_value?(RELEASED_FEATURES, feature_key) || @storage.has_value?(feature_key, resource_id)
     end
 
-    def released_keys(features_keys, resource_id)
+    def released_features(features_keys, resource_id)
       @storage.pipelined do
         features_keys.select { |f| @storage.has_value?(f, resource_id) }
       end

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -12,6 +12,11 @@ module FeatureFlagger
       @storage.has_value?(RELEASED_FEATURES, feature_key) || @storage.has_value?(feature_key, resource_id)
     end
 
+    def released_keys(feature_key, resource_id)
+      features = @storage.all_keys(feature_key)
+      features.map { @storage.has_value?(feature_key, resource_id) }
+    end
+
     def release(feature_key, resource_id)
       @storage.add(feature_key, resource_id)
     end

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -16,7 +16,7 @@ module FeatureFlagger
       features_has_values = @storage.pipelined do
         features_keys.select { |f| @storage.has_value?(f, resource_id) }
       end
-      
+
       released_features = Hash[features_keys.zip(features_has_values)]
       released_features.select { |_, value| value }
                        .collect { |key,_| key }

--- a/lib/feature_flagger/feature.rb
+++ b/lib/feature_flagger/feature.rb
@@ -1,6 +1,6 @@
 module FeatureFlagger
   class Feature
-    def initialize(feature_key = nil, resource_name)
+    def initialize(feature_key, resource_name = nil)
       @feature_key = resolve_key(feature_key, resource_name)
       @doc = self.class.fetch_config
       fetch_data

--- a/lib/feature_flagger/feature.rb
+++ b/lib/feature_flagger/feature.rb
@@ -14,6 +14,10 @@ module FeatureFlagger
       @feature_key.join(':')
     end
 
+    def childs_keys
+      @data.collect { |child_key, _| "#{key}:#{child_key}" }
+    end
+
     private
 
     def resolve_key(feature_key, resource_name)

--- a/lib/feature_flagger/feature.rb
+++ b/lib/feature_flagger/feature.rb
@@ -1,11 +1,8 @@
 module FeatureFlagger
   class Feature
-    def initialize(feature_key = nil, resource_name = nil)
-      @resource_name = resource_name
-      @doc = FeatureFlagger.config.info
-      return if feature_key == nil
-
+    def initialize(feature_key = nil, resource_name)
       @feature_key = resolve_key(feature_key, resource_name)
+      @doc = self.class.fetch_config
       fetch_data
     end
 
@@ -18,26 +15,20 @@ module FeatureFlagger
     end
 
     def childs_keys
-      return all_keys if @feature_key == nil
-
       @data.select { |child_key, _| child_key != 'description' }
            .collect { |child_key, _| "#{key}:#{child_key}" }
     end
 
-    private
-
-    def all_keys
+    def self.all_keys(resource_name)
       keys_and_child_keys = root_features.map do |key|
-        feature = Feature.new([key], @resource_name)
+        feature = Feature.new([key], resource_name)
         [feature.key] + feature.childs_keys
       end
 
       keys_and_child_keys.flatten
     end
 
-    def root_features
-      @doc[@doc.keys.first].keys
-    end
+    private
 
     def resolve_key(feature_key, resource_name)
       key = Array(feature_key).flatten
@@ -59,6 +50,15 @@ module FeatureFlagger
       else
         find_value(value, *tail)
       end
+    end
+
+    def self.root_features
+      doc = fetch_config
+      doc[doc.keys.first].keys
+    end
+
+    def self.fetch_config
+      FeatureFlagger.config.info
     end
   end
 end

--- a/lib/feature_flagger/feature.rb
+++ b/lib/feature_flagger/feature.rb
@@ -15,7 +15,8 @@ module FeatureFlagger
     end
 
     def childs_keys
-      @data.collect { |child_key, _| "#{key}:#{child_key}" }
+      @data.select { |child_key, _| child_key != 'description' }
+           .collect { |child_key, _| "#{key}:#{child_key}" }
     end
 
     private

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -52,7 +52,7 @@ module FeatureFlagger
 
       def released_keys(resource_id, *feature_key)
         feature = Feature.new(feature_key, rollout_resource_name)
-        FeatureFlagger.control.released_keys(feature.key, resource_id)
+        FeatureFlagger.control.released_keys(feature.childs_keys, resource_id)
       end
 
       def all_released_ids_for(*feature_key)

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -16,6 +16,10 @@ module FeatureFlagger
       self.class.released_id?(id, feature_key)
     end
 
+    def released_keys(*feature_key)
+      self.class.released_keys(id, feature_key)
+    end
+
     # <b>DEPRECATED:</b> Please use <tt>release</tt> instead.
     def release!(*feature_key)
       warn "[DEPRECATION] `release!` is deprecated.  Please use `release` instead."
@@ -44,6 +48,11 @@ module FeatureFlagger
       def released_id?(resource_id, *feature_key)
         feature = Feature.new(feature_key, rollout_resource_name)
         FeatureFlagger.control.rollout?(feature.key, resource_id)
+      end
+
+      def released_keys(resource_id, *feature_key)
+        feature = Feature.new(feature_key, rollout_resource_name)
+        FeatureFlagger.control.released_keys(feature.key, resource_id)
       end
 
       def all_released_ids_for(*feature_key)

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -16,8 +16,8 @@ module FeatureFlagger
       self.class.released_id?(id, feature_key)
     end
 
-    def released_keys(*feature_key)
-      self.class.released_keys(id, feature_key)
+    def released_features(*feature_key)
+      self.class.released_features(id, feature_key)
     end
 
     # <b>DEPRECATED:</b> Please use <tt>release</tt> instead.
@@ -50,9 +50,9 @@ module FeatureFlagger
         FeatureFlagger.control.rollout?(feature.key, resource_id)
       end
 
-      def released_keys(resource_id, *feature_key)
+      def released_features(resource_id, *feature_key)
         feature = Feature.new(feature_key, rollout_resource_name)
-        FeatureFlagger.control.released_keys(feature.childs_keys, resource_id)
+        FeatureFlagger.control.released_features(feature.childs_keys, resource_id)
       end
 
       def all_released_ids_for(*feature_key)

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -51,8 +51,13 @@ module FeatureFlagger
       end
 
       def released_features(resource_id, *feature_key)
-        feature = Feature.new(feature_key, rollout_resource_name)
-        FeatureFlagger.control.released_features(feature.childs_keys, resource_id)
+        if feature_key
+          features_keys = Feature.new(feature_key, rollout_resource_name).childs_keys
+        else
+          features_keys = Feature.all_keys(rollout_resource_name)
+        end
+        
+        FeatureFlagger.control.released_features(features_keys, resource_id)
       end
 
       def all_released_ids_for(*feature_key)

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -51,7 +51,8 @@ module FeatureFlagger
       end
 
       def released_features(resource_id, *feature_key)
-        if feature_key
+        feature_key.flatten!
+        if feature_key.any?
           features_keys = Feature.new(feature_key, rollout_resource_name).childs_keys
         else
           features_keys = Feature.all_keys(rollout_resource_name)

--- a/lib/feature_flagger/storage/redis.rb
+++ b/lib/feature_flagger/storage/redis.rb
@@ -33,8 +33,8 @@ module FeatureFlagger
         @redis.smembers(key)
       end
 
-      def all_keys(filter)
-        @redis.keys(filter)
+      def pipelined
+        yield
       end
     end
   end

--- a/lib/feature_flagger/storage/redis.rb
+++ b/lib/feature_flagger/storage/redis.rb
@@ -34,7 +34,9 @@ module FeatureFlagger
       end
 
       def pipelined
-        yield
+        @redis.pipelined do
+          yield
+        end
       end
     end
   end

--- a/lib/feature_flagger/storage/redis.rb
+++ b/lib/feature_flagger/storage/redis.rb
@@ -33,8 +33,8 @@ module FeatureFlagger
         @redis.smembers(key)
       end
 
-      def all_keys(prefix)
-        @redis.keys("prefix*")
+      def all_keys(filter)
+        @redis.keys(filter)
       end
     end
   end

--- a/lib/feature_flagger/storage/redis.rb
+++ b/lib/feature_flagger/storage/redis.rb
@@ -32,6 +32,10 @@ module FeatureFlagger
       def all_values(key)
         @redis.smembers(key)
       end
+
+      def all_keys(prefix)
+        @redis.keys("prefix*")
+      end
     end
   end
 end

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -37,27 +37,26 @@ module FeatureFlagger
     end
 
     describe '#released_keys' do
-      let(:result) { control.released_keys(key, resource_id) }
-
-      context 'given exists key, key1, key2 and notkey features' do
+      let(:keys) { %w(key key1 key2 key3 key4) }
+      context 'given exists key, key2 and key3 features' do
         before {
           storage.add(key, %w(resource_id another_resource_id))
           storage.add('key1', %w(resource_id another_resource_id)) 
           storage.add('key2', another_resource_id) 
-          storage.add('notkey', resource_id) 
+          storage.add('key3', resource_id)
         }
 
         context 'when resource entity id has access to key, key1 and notkey' do
           it { 
-            result = control.released_keys(key, resource_id)
-            expect(result).to eq(%w(key key1)) 
+            result = control.released_keys?(keys, resource_id)
+            expect(result).to eq(%w(key key1 key3))
           }
         end
 
         context 'when resource entity id has access to key, key1 and key2' do
           it { 
-            result = control.released_keys(key, another_resource_id)
-            expect(result).to eq(%w(key key1 key2)) 
+            result = control.released_keys?(keys, another_resource_id)
+            expect(result).to eq(%w(key key1 key2))
           }
         end
       end

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -37,11 +37,12 @@ module FeatureFlagger
 
     describe '#released_keys' do
       let(:another_resource_id) { 'another_resource_id' }
+      let(:without_release_resource_id) { 'without_release_resource_id' }
       let(:keys) { %w(key key1 key2 key3) }
       let(:keys_resource) { %w(key key1 key3) }
       let(:keys_another_resource) { %w(key key1 key2 key3) }
 
-      context 'given exists key, key2 and key3 features' do
+      context 'given exists key, key1, key2 and key3 features' do
         before {
           keys.map do |key|
             values = [resource_id, another_resource_id]
@@ -50,17 +51,24 @@ module FeatureFlagger
           end
         }
 
-        context 'when resource entity id has access to key, key1 and notkey' do
+        context 'when resource entity id has access to key, key1 and key3' do
           it { 
             result = control.released_keys(keys, resource_id)
             expect(result).to eq(keys_resource)
           }
         end
 
-        context 'when resource entity id has access to key, key1 and key2' do
+        context 'when resource entity id has access to key, key1, key2 and key3' do
           it { 
             result = control.released_keys(keys, another_resource_id)
             expect(result).to eq(keys_another_resource)
+          }
+        end
+
+        context 'when resource entity id has no access' do
+          it { 
+            result = control.released_keys(keys, without_release_resource_id)
+            expect(result).to eq([])
           }
         end
       end

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -50,14 +50,14 @@ module FeatureFlagger
         context 'when resource entity id has access to key, key1 and notkey' do
           it { 
             result = control.released_keys(key, resource_id)
-            expect(result).to eq(%w(key1)) 
+            expect(result).to eq(%w(key key1)) 
           }
         end
 
         context 'when resource entity id has access to key, key1 and key2' do
           it { 
-            result = control.released_keys(key, resource_id)
-            expect(result).to eq(%w(key1 key2)) 
+            result = control.released_keys(key, another_resource_id)
+            expect(result).to eq(%w(key key1 key2)) 
           }
         end
       end

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -35,7 +35,7 @@ module FeatureFlagger
       end
     end
 
-    describe '#released_keys' do
+    describe '#released_features' do
       let(:another_resource_id) { 'another_resource_id' }
       let(:without_release_resource_id) { 'without_release_resource_id' }
       let(:keys) { %w(key key1 key2 key3) }
@@ -53,21 +53,21 @@ module FeatureFlagger
 
         context 'when resource entity id has access to key, key1 and key3' do
           it { 
-            result = control.released_keys(keys, resource_id)
+            result = control.released_features(keys, resource_id)
             expect(result).to eq(keys_resource)
           }
         end
 
         context 'when resource entity id has access to key, key1, key2 and key3' do
           it { 
-            result = control.released_keys(keys, another_resource_id)
+            result = control.released_features(keys, another_resource_id)
             expect(result).to eq(keys_another_resource)
           }
         end
 
         context 'when resource entity id has no access' do
           it { 
-            result = control.released_keys(keys, without_release_resource_id)
+            result = control.released_features(keys, without_release_resource_id)
             expect(result).to eq([])
           }
         end

--- a/spec/feature_flagger/feature_spec.rb
+++ b/spec/feature_flagger/feature_spec.rb
@@ -44,12 +44,23 @@ module FeatureFlagger
     end
 
     describe '#childs_keys' do
+      context 'given a nil feature' do
+        let(:key) { nil }
+        childs_keys = %w(feature_flagger_dummy_class:email_marketing
+                         feature_flagger_dummy_class:email_marketing:behavior_score
+                         feature_flagger_dummy_class:email_marketing:whitelabel)
+
+        it 'returns all features keys from config' do
+          expect(subject.childs_keys).to eq childs_keys
+        end
+      end
+
       context 'given feature has childs' do
-        let(:key) { :email_marketing }
+        let(:key) { [:email_marketing] }
 
         it 'returns childs keys from feature' do
           childs_keys = %w(feature_flagger_dummy_class:email_marketing:behavior_score
-                          feature_flagger_dummy_class:email_marketing:whitelabel) 
+                          feature_flagger_dummy_class:email_marketing:whitelabel)
 
           expect(subject.childs_keys).to eq childs_keys
         end

--- a/spec/feature_flagger/feature_spec.rb
+++ b/spec/feature_flagger/feature_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 module FeatureFlagger
   RSpec.describe Feature do
-    subject { Feature.new(key, :feature_flagger_dummy_class) }
+    let(:resource_name) { :feature_flagger_dummy_class }
+    subject { Feature.new(key, resource_name) }
 
     before do
       filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
@@ -44,17 +45,6 @@ module FeatureFlagger
     end
 
     describe '#childs_keys' do
-      context 'given a nil feature' do
-        let(:key) { nil }
-        childs_keys = %w(feature_flagger_dummy_class:email_marketing
-                         feature_flagger_dummy_class:email_marketing:behavior_score
-                         feature_flagger_dummy_class:email_marketing:whitelabel)
-
-        it 'returns all features keys from config' do
-          expect(subject.childs_keys).to eq childs_keys
-        end
-      end
-
       context 'given feature has childs' do
         let(:key) { [:email_marketing] }
 
@@ -72,6 +62,16 @@ module FeatureFlagger
         it 'returns empty' do
           expect(subject.childs_keys).to eq []
         end
+      end
+    end
+
+    describe '#all_keys' do
+      it 'returns all features keys from config' do
+        all_keys = %w(feature_flagger_dummy_class:email_marketing
+                         feature_flagger_dummy_class:email_marketing:behavior_score
+                         feature_flagger_dummy_class:email_marketing:whitelabel)
+
+        expect(Feature.all_keys(resource_name)).to eq all_keys
       end
     end
   end

--- a/spec/feature_flagger/feature_spec.rb
+++ b/spec/feature_flagger/feature_spec.rb
@@ -42,5 +42,26 @@ module FeatureFlagger
         expect(subject.key).to eq resolved_key
       end
     end
+
+    describe '#childs_keys' do
+      context 'given feature has childs' do
+        let(:key) { :email_marketing }
+
+        it 'returns childs keys from feature' do
+          childs_keys = %w(feature_flagger_dummy_class:email_marketing:behavior_score
+                          feature_flagger_dummy_class:email_marketing:whitelabel) 
+
+          expect(subject.childs_keys).to eq childs_keys
+        end
+      end
+
+      context 'given feature has not childs' do
+        let(:key) { [:email_marketing, :whitelabel] }
+
+        it 'returns empty' do
+          expect(subject.childs_keys).to eq []
+        end
+      end
+    end
   end
 end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -34,8 +34,11 @@ module FeatureFlagger
 
     describe '#released_keys' do
       it 'calls Control#released_keys with appropriated methods' do
-        expect(control).to receive(:released_keys).with(resolved_key, subject.id)
-        subject.released_keys(key)
+        childs = %w(feature_flagger_dummy_class:email_marketing:behavior_score
+                    feature_flagger_dummy_class:email_marketing:whitelabel)
+
+        expect(control).to receive(:released_keys).with(childs, subject.id)
+        subject.released_keys(:email_marketing)
       end
     end
 

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -32,6 +32,13 @@ module FeatureFlagger
       end
     end
 
+    describe '#released_keys' do
+      it 'calls Control#released_keys with appropriated methods' do
+        expect(control).to receive(:released_keys).with(resolved_key, subject.id)
+        subject.released_keys(key)
+      end
+    end
+
     describe '#unrelease' do
       it 'calls Control#unrelease with appropriated methods' do
         expect(control).to receive(:unrelease).with(resolved_key, subject.id)

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -34,10 +34,10 @@ module FeatureFlagger
 
     describe '#released_keys' do
       it 'calls Control#released_keys with appropriated methods' do
-        childs = %w(feature_flagger_dummy_class:email_marketing:behavior_score
+        childs_keys = %w(feature_flagger_dummy_class:email_marketing:behavior_score
                     feature_flagger_dummy_class:email_marketing:whitelabel)
 
-        expect(control).to receive(:released_keys).with(childs, subject.id)
+        expect(control).to receive(:released_keys).with(childs_keys, subject.id)
         subject.released_keys(:email_marketing)
       end
     end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -40,6 +40,10 @@ module FeatureFlagger
         expect(control).to receive(:released_features).with(childs_keys, subject.id)
         subject.released_features(:email_marketing)
       end
+
+      context 'given featured_keys is not informed' do
+
+      end
     end
 
     describe '#unrelease' do

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -32,13 +32,13 @@ module FeatureFlagger
       end
     end
 
-    describe '#released_keys' do
-      it 'calls Control#released_keys with appropriated methods' do
+    describe '#released_features' do
+      it 'calls Control#released_features with appropriated methods' do
         childs_keys = %w(feature_flagger_dummy_class:email_marketing:behavior_score
                     feature_flagger_dummy_class:email_marketing:whitelabel)
 
-        expect(control).to receive(:released_keys).with(childs_keys, subject.id)
-        subject.released_keys(:email_marketing)
+        expect(control).to receive(:released_features).with(childs_keys, subject.id)
+        subject.released_features(:email_marketing)
       end
     end
 

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -35,14 +35,21 @@ module FeatureFlagger
     describe '#released_features' do
       it 'calls Control#released_features with appropriated methods' do
         childs_keys = %w(feature_flagger_dummy_class:email_marketing:behavior_score
-                    feature_flagger_dummy_class:email_marketing:whitelabel)
+                         feature_flagger_dummy_class:email_marketing:whitelabel)
 
         expect(control).to receive(:released_features).with(childs_keys, subject.id)
         subject.released_features(:email_marketing)
       end
 
       context 'given featured_keys is not informed' do
+        it 'calls Control#released_features with appropriated methods' do
+          childs_keys = %w(feature_flagger_dummy_class:email_marketing
+                           feature_flagger_dummy_class:email_marketing:behavior_score
+                           feature_flagger_dummy_class:email_marketing:whitelabel)
 
+          expect(control).to receive(:released_features).with(childs_keys, subject.id)
+          subject.released_features
+        end
       end
     end
 

--- a/spec/feature_flagger/storage/redis_spec.rb
+++ b/spec/feature_flagger/storage/redis_spec.rb
@@ -45,15 +45,5 @@ RSpec.describe FeatureFlagger::Storage::Redis do
         expect(storage.all_values(key).sort).to eq values.sort
       end
     end
-
-    describe '#all_keys' do
-      it 'returns all keys for the filter key' do
-        filter = 'prefix*'
-        keys = %w(prefix:value1 prefix:value2 not_prefix:value1)
-        keys.map { |k| redis.sadd(k, value) }
-
-        expect(storage.all_keys(filter)).to eq(%w(prefix:value1 prefix:value2))
-      end
-    end
   end
 end

--- a/spec/feature_flagger/storage/redis_spec.rb
+++ b/spec/feature_flagger/storage/redis_spec.rb
@@ -45,5 +45,15 @@ RSpec.describe FeatureFlagger::Storage::Redis do
         expect(storage.all_values(key).sort).to eq values.sort
       end
     end
+
+    describe '#all_keys' do
+      it 'returns all keys for the filter key' do
+        filter = 'prefix*'
+        keys = %w(prefix:value1 prefix:value2 not_prefix:value1)
+        keys.map { |k| redis.sadd(k, value) }
+
+        expect(storage.all_keys(filter)).to eq(%w(prefix:value1 prefix:value2))
+      end
+    end
   end
 end


### PR DESCRIPTION
Implemented a method to return releases which resource has access under a chain. Suggested in #28 

## Example

##### Given
```
acc = Account.find 1
acc.release(:email_marketing, :behavior_score)
acc.release(:email_marketing, :whitelabel)
```
##### Use
```
acc.released_keys(:email_marketing)
```
#### Returns
```
['account:email_marketing:behavior_score', 'account:email_marketing:whitelabel']
```

I'm not totally happy with this response with feature key, but we need to resolve child of child of child (ad infinitum) features. So I inspired response in released_to_all email. Give me suggestions! :smiley: 
