### PR TITLE
Add static method for releasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ FeatureFlagger::KeyNotFoundError: ["account", "email_marketing", "new_email_flo"
 Account.released_id?(42, :email_marketing, :new_email_flow)
 #=> true
 
+# Release a feature for a specific account id
+Account.release_id(42, :email_marketing, :new_email_flow)
+#=> true
+
 # Get an array with all released Account ids
 Account.all_released_ids_for(:email_marketing, :new_email_flow)
 

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -23,9 +23,7 @@ module FeatureFlagger
     end
 
     def release(*feature_key)
-      resource_name = self.class.rollout_resource_name
-      feature = Feature.new(feature_key, resource_name)
-      FeatureFlagger.control.release(feature.key, id)
+      self.class.release_id(id, *feature_key)
     end
 
     # <b>DEPRECATED:</b> Please use <tt>unrelease</tt> instead.
@@ -44,6 +42,11 @@ module FeatureFlagger
       def released_id?(resource_id, *feature_key)
         feature = Feature.new(feature_key, rollout_resource_name)
         FeatureFlagger.control.rollout?(feature.key, resource_id)
+      end
+
+      def release_id(resource_id, *feature_key)
+        feature = Feature.new(feature_key, rollout_resource_name)
+        FeatureFlagger.control.release(feature.key, resource_id)
       end
 
       def all_released_ids_for(*feature_key)

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -50,6 +50,17 @@ module FeatureFlagger
       end
     end
 
+    describe '.release_id' do
+      context 'given a specific resource id' do
+        let(:resource_id) { 10 }
+
+        it 'calls Control#release with appropriated methods' do
+          expect(control).to receive(:release).with(resolved_key, resource_id)
+          DummyClass.release_id(resource_id, key)
+        end
+      end
+    end
+
     describe '.all_released_ids_for' do
       it 'calls Control#resource_ids with appropriated methods' do
         expect(control).to receive(:resource_ids).with(resolved_key)


### PR DESCRIPTION
Often I find myself with a list of ids and a feature and I'm forced to instantiate a lot of useless objects.

```ruby
accounts = Account.where(id: account_ids)
    accounts.each do |account|
      account.release(:cdp,:timeline)  
    end
end
```

Ideally, we could introduce a method that would release for a list of ids, but the current signature does not allow this without breaking changes.