### PR TITLE
Rename rollout? method to released?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in rollout.gemspec
+# Specify your gem's dependencies in feature_flagger.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ account.release(:email_marketing, :new_email_flow)
 #=> true
 
 # Check feature for a given account
-account.rollout?(:email_marketing, :new_email_flow)
+account.released?(:email_marketing, :new_email_flow)
 #=> true
 
 # Remove feature for given account
@@ -71,7 +71,7 @@ account.unrelease(:email_marketing, :new_email_flow)
 #=> true
 
 # If you try to check an inexistent rollout key it will raise an error.
-account.rollout?(:email_marketing, :new_email_flow)
+account.released?(:email_marketing, :new_email_flow)
 FeatureFlagger::KeyNotFoundError: ["account", "email_marketing", "new_email_flo"]
 
 # Check feature for a specific account id

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "rollout"
+require "feature_flagger"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -8,8 +8,13 @@ module FeatureFlagger
       @storage = storage
     end
 
-    def rollout?(feature_key, resource_id)
+    def released?(feature_key, resource_id)
       @storage.has_value?(RELEASED_FEATURES, feature_key) || @storage.has_value?(feature_key, resource_id)
+    end
+
+    def rollout?(feature_key, resource_id)
+      warn "[DEPRECATION] `rollou?` is deprecated.  Please use `released?` instead."
+      released?(feature_key, resource_id)
     end
 
     def release(feature_key, resource_id)

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -13,7 +13,7 @@ module FeatureFlagger
     end
 
     def rollout?(feature_key, resource_id)
-      warn "[DEPRECATION] `rollou?` is deprecated.  Please use `released?` instead."
+      warn "[DEPRECATION] `rollout?` is deprecated.  Please use `released?` instead."
       released?(feature_key, resource_id)
     end
 

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -12,8 +12,14 @@ module FeatureFlagger
       base.extend ClassMethods
     end
 
-    def rollout?(*feature_key)
+    def released?(*feature_key)
       self.class.released_id?(id, feature_key)
+    end
+
+    # <b>DEPRECATED:</b> Please use <tt>release</tt> instead.
+    def rollout?(*feature_key)
+      warn "[DEPRECATION] `rollout?` is deprecated.  Please use `released?` instead."
+      released?(*feature_key)
     end
 
     # <b>DEPRECATED:</b> Please use <tt>release</tt> instead.
@@ -43,7 +49,7 @@ module FeatureFlagger
     module ClassMethods
       def released_id?(resource_id, *feature_key)
         feature = Feature.new(feature_key, rollout_resource_name)
-        FeatureFlagger.control.rollout?(feature.key, resource_id)
+        FeatureFlagger.control.released?(feature.key, resource_id)
       end
 
       def all_released_ids_for(*feature_key)

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -12,6 +12,29 @@ module FeatureFlagger
       redis.flushdb
     end
 
+    describe '#released?' do
+      let(:result) { control.released?(key, resource_id) }
+
+      context 'when resource entity id has no access to release_key' do
+        it { expect(result).to be_falsey }
+
+        context 'and a feature is release to all' do
+          before { storage.add(FeatureFlagger::Control::RELEASED_FEATURES, key) }
+          it { expect(result).to be_truthy }
+        end
+      end
+
+      context 'when resource entity id has access to release_key' do
+        before { storage.add(key, resource_id) }
+        it { expect(result).to be_truthy }
+
+        context 'and a feature is release to all' do
+          before { storage.add(FeatureFlagger::Control::RELEASED_FEATURES, key) }
+          it { expect(result).to be_truthy }
+        end
+      end
+    end
+
     describe '#rollout?' do
       let(:result) { control.rollout?(key, resource_id) }
 

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -26,9 +26,9 @@ module FeatureFlagger
     end
 
     describe '#rollout?' do
-      it 'calls Control#rollout? with appropriated methods' do
-        expect(control).to receive(:rollout?).with(resolved_key, subject.id)
-        subject.rollout?(key)
+      it 'calls Control#released? with appropriated methods' do
+        expect(control).to receive(:released?).with(resolved_key, subject.id)
+        subject.released?(key)
       end
     end
 
@@ -43,8 +43,8 @@ module FeatureFlagger
       context 'given a specific resource id' do
         let(:resource_id) { 10 }
 
-        it 'calls Control#rollout? with appropriated methods' do
-          expect(control).to receive(:rollout?).with(resolved_key, resource_id)
+        it 'calls Control#released? with appropriated methods' do
+          expect(control).to receive(:released?).with(resolved_key, resource_id)
           DummyClass.released_id?(resource_id, key)
         end
       end


### PR DESCRIPTION
All other methods were named accordinly.
This increases consistency.
Kept `rollout?` with a warning to prevent a breaking change.

I think we can soon bump the major version removing the accumulated deprecations.