### PR TITLE
Fix unrelease to all

### DIFF
--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -17,7 +17,7 @@ module FeatureFlagger
     end
 
     def release_to_all(feature_key)
-      @storage.add(RELEASED_FEATURES, feature_key)
+      @storage.add_all(RELEASED_FEATURES, feature_key)
     end
 
     def unrelease(feature_key, resource_id)
@@ -25,7 +25,7 @@ module FeatureFlagger
     end
 
     def unrelease_to_all(feature_key)
-      @storage.remove(RELEASED_FEATURES, feature_key)
+      @storage.remove_all(RELEASED_FEATURES, feature_key)
     end
 
     def resource_ids(feature_key)

--- a/lib/feature_flagger/storage/redis.rb
+++ b/lib/feature_flagger/storage/redis.rb
@@ -29,6 +29,20 @@ module FeatureFlagger
         @redis.srem(key, value)
       end
 
+      def remove_all(global_key, key)
+        @redis.multi do |redis|
+          redis.srem(global_key, key)
+          redis.del(key)
+        end
+      end
+
+      def add_all(global_key, key)
+        @redis.multi do |redis|
+          redis.sadd(global_key, key)
+          redis.del(key)
+        end
+      end
+
       def all_values(key)
         @redis.smembers(key)
       end

--- a/lib/feature_flagger/version.rb
+++ b/lib/feature_flagger/version.rb
@@ -1,3 +1,3 @@
 module FeatureFlagger
-  VERSION = "0.7.3"
+  VERSION = "0.7.4"
 end

--- a/lib/feature_flagger/version.rb
+++ b/lib/feature_flagger/version.rb
@@ -1,3 +1,3 @@
 module FeatureFlagger
-  VERSION = "0.7.4"
+  VERSION = "0.7.3"
 end

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -44,7 +44,9 @@ module FeatureFlagger
 
     describe '#release_to_all' do
       it 'adds feature_key to storage' do
+        storage.add(key, 1)
         control.release_to_all(key)
+        expect(storage).not_to have_value(key, 1)
         expect(storage).to have_value(FeatureFlagger::Control::RELEASED_FEATURES, key)
       end
     end
@@ -61,6 +63,13 @@ module FeatureFlagger
       it 'removes feature_key to storage' do
         storage.add(FeatureFlagger::Control::RELEASED_FEATURES, key)
         control.unrelease_to_all(key)
+        expect(storage).not_to have_value(FeatureFlagger::Control::RELEASED_FEATURES, key)
+      end
+
+      it 'removes added resources' do
+        storage.add(key, 1)
+        control.unrelease_to_all(key)
+        expect(storage).not_to have_value(key, 1)
         expect(storage).not_to have_value(FeatureFlagger::Control::RELEASED_FEATURES, key)
       end
     end

--- a/spec/feature_flagger/storage/redis_spec.rb
+++ b/spec/feature_flagger/storage/redis_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe FeatureFlagger::Storage::Redis do
   let(:storage) { described_class.new(redis) }
   let(:key)   { 'foo' }
   let(:value) { 'bar' }
+  let(:global_key) { 'released_features' }
 
   context do
     before do
@@ -29,10 +30,26 @@ RSpec.describe FeatureFlagger::Storage::Redis do
       end
     end
 
+    describe '#add_all' do
+      it 'adds value to redis global key and clear key' do
+        storage.add_all(global_key, key)
+        expect(redis.sismember(global_key, key)).to be_truthy
+        expect(redis.sismember(key, value)).to be_falsey
+      end
+    end
+
     describe '#remove' do
       it 'removes the value from redis' do
         redis.sadd(key, value)
         storage.remove(key, value)
+        expect(redis.sismember(key, value)).to be_falsey
+      end
+    end
+
+    describe '#remove_all' do
+      it 'removes all values from redis' do
+        redis.sadd(key, value)
+        storage.remove_all(global_key, key)
         expect(redis.sismember(key, value)).to be_falsey
       end
     end


### PR DESCRIPTION
Fixes #45 

## Proposed changes
- When a `release_to_all` is used: 
  - [x] Remove all resources from their set and add it's key to globally released features.
- When `unrelease_to_all` is used:
  - [x]  Remove all resources from their set and also remove key from globally released features
