### PR TITLE
Create released_to_all? method

### DIFF
--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -35,5 +35,9 @@ module FeatureFlagger
     def released_features_to_all
       @storage.all_values(RELEASED_FEATURES)
     end
+
+    def released_to_all?(feature_key)
+      @storage.has_value?(RELEASED_FEATURES, feature_key)
+    end
   end
 end

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -57,6 +57,11 @@ module FeatureFlagger
         FeatureFlagger.control.released_features_to_all
       end
 
+      def released_to_all?(*feature_key)
+        feature = Feature.new(feature_key, rollout_resource_name)
+        FeatureFlagger.control.released_to_all?(feature.key)
+      end
+
       def rollout_resource_name
         klass_name = self.to_s
         klass_name.gsub!(/::/, '_')

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -86,5 +86,19 @@ module FeatureFlagger
         is_expected.to match_array %w(feature::name1 feature::name2 feature::name15)
       end
     end
+
+    describe '#released_to_all?' do
+      let(:result) { control.released_to_all?(key) }
+
+      context 'when feature was not released to all' do
+        before { storage.remove(FeatureFlagger::Control::RELEASED_FEATURES, key) }
+        it { expect(result).to be_falsey}
+      end
+
+      context 'when feature was released to all' do
+        before { storage.add(FeatureFlagger::Control::RELEASED_FEATURES, key) }
+        it { expect(result).to be_truthy}
+      end
+    end
   end
 end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -76,7 +76,7 @@ module FeatureFlagger
     end
 
     describe '.released_features_to_all' do
-      it 'calls Control#resource_ids with appropriated methods' do
+      it 'calls Control#released_features_to_all with appropriated methods' do
         expect(control).to receive(:released_features_to_all)
         DummyClass.released_features_to_all
       end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -81,5 +81,12 @@ module FeatureFlagger
         DummyClass.released_features_to_all
       end
     end
+
+    describe '.released_to_all?' do
+      it 'calls Control#released_to_all? with appropriated methods' do
+        expect(control).to receive(:released_to_all?).with(resolved_key)
+        DummyClass.released_to_all?(key)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Proposed Changes

- Creates a new method `released_to_all?`, that receives a feature and:
  - [ ] Returns `true` if feature was released to all;
  - [ ] Returns `false` if feature is not released to all yet;

## Example

```ruby
Account.released_to_all?(:foo, :bar)
=> true 
```