### PR TITLE
Cleaning up removed rollouts

### DIFF
--- a/lib/feature_flagger.rb
+++ b/lib/feature_flagger.rb
@@ -6,6 +6,7 @@ require 'feature_flagger/control'
 require 'feature_flagger/model'
 require 'feature_flagger/feature'
 require 'feature_flagger/configuration'
+require 'feature_flagger/manager'
 
 module FeatureFlagger
   class << self

--- a/lib/feature_flagger/configuration.rb
+++ b/lib/feature_flagger/configuration.rb
@@ -11,10 +11,36 @@ module FeatureFlagger
       @info ||= YAML.load_file(yaml_filepath) if yaml_filepath
     end
 
+    def mapped_feature_keys(resource_name = nil)
+      info_filtered = resource_name ? info[resource_name] : info
+      [].tap do |keys|
+        make_keys_recursively(info_filtered).each { |key| keys.push(join_key(resource_name, key)) }
+      end
+    end
+
     private
 
     def default_yaml_filepath
       "#{Rails.root}/config/rollout.yml" if defined?(Rails)
+    end
+
+    def make_keys_recursively(hash, keys = [], composed_key = [])
+      unless hash.values[0].is_a?(Hash)
+        keys.push(composed_key)
+        return
+      end
+
+      hash.each do |key, value|
+        composed_key_cloned = composed_key.clone
+        composed_key_cloned.push(key.to_sym)
+        make_keys_recursively(value, keys, composed_key_cloned)
+      end
+      keys
+    end
+
+    def join_key(resource_name, key)
+      key.unshift resource_name if resource_name
+      key.join(":")
     end
   end
 end

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -39,5 +39,9 @@ module FeatureFlagger
     def released_to_all?(feature_key)
       @storage.has_value?(RELEASED_FEATURES, feature_key)
     end
+
+    def search_keys(query)
+      @storage.search_keys(query)
+    end
   end
 end

--- a/lib/feature_flagger/manager.rb
+++ b/lib/feature_flagger/manager.rb
@@ -7,9 +7,11 @@ module FeatureFlagger
       persisted_features - mapped_feature_keys
     end
 
-    def self.remove_detached_feature_key(key)
-      raise "key is still mapped" if FeatureFlagger.config.info.dig(*key.split(":"))
-      FeatureFlagger.control.unrelease_to_all(key)
+    def self.cleanup_detached(resource_name, *feature_key)
+      complete_feature_key = feature_key.map(&:to_s).insert(0, resource_name.to_s)
+      key_value = FeatureFlagger.config.info.dig(*complete_feature_key)
+      raise "key is still mapped" if key_value
+      FeatureFlagger.control.unrelease_to_all(complete_feature_key.join(':'))
     end
 
   end

--- a/lib/feature_flagger/manager.rb
+++ b/lib/feature_flagger/manager.rb
@@ -1,0 +1,35 @@
+module FeatureFlagger
+  class Manager
+
+    def self.mapped_feature_keys
+      [].tap do |keys|
+        make_keys_recursively(FeatureFlagger.config.info).each { |key| keys.push(key.join(":")) }
+      end
+    end
+
+    def self.detached_feature_keys
+      persisted_features = FeatureFlagger.control.search_keys("*").to_a
+      persisted_features - mapped_feature_keys
+    end
+
+    def self.remove_feature_key(key)
+      FeatureFlagger.control.unrelease_to_all(key)
+    end
+
+    private
+
+    def self.make_keys_recursively(hash, keys = [], composed_key = [])
+      unless hash.values[0].is_a?(Hash)
+        keys.push(composed_key)
+        return
+      end
+
+      hash.each do |key, value|
+        composed_key_cloned = composed_key.clone
+        composed_key_cloned.push(key.to_sym)
+        make_keys_recursively(value, keys, composed_key_cloned)
+      end
+      keys
+    end
+  end
+end

--- a/lib/feature_flagger/manager.rb
+++ b/lib/feature_flagger/manager.rb
@@ -1,35 +1,16 @@
 module FeatureFlagger
   class Manager
 
-    def self.mapped_feature_keys
-      [].tap do |keys|
-        make_keys_recursively(FeatureFlagger.config.info).each { |key| keys.push(key.join(":")) }
-      end
-    end
-
     def self.detached_feature_keys
       persisted_features = FeatureFlagger.control.search_keys("*").to_a
+      mapped_feature_keys = FeatureFlagger.config.mapped_feature_keys
       persisted_features - mapped_feature_keys
     end
 
-    def self.remove_feature_key(key)
+    def self.remove_detached_feature_key(key)
+      raise "key is still mapped" if FeatureFlagger.config.info.dig(*key.split(":"))
       FeatureFlagger.control.unrelease_to_all(key)
     end
 
-    private
-
-    def self.make_keys_recursively(hash, keys = [], composed_key = [])
-      unless hash.values[0].is_a?(Hash)
-        keys.push(composed_key)
-        return
-      end
-
-      hash.each do |key, value|
-        composed_key_cloned = composed_key.clone
-        composed_key_cloned.push(key.to_sym)
-        make_keys_recursively(value, keys, composed_key_cloned)
-      end
-      keys
-    end
   end
 end

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -27,6 +27,7 @@ module FeatureFlagger
     end
 
     module ClassMethods
+
       def released_id?(resource_id, *feature_key)
         feature = Feature.new(feature_key, rollout_resource_name)
         FeatureFlagger.control.released?(feature.key, resource_id)
@@ -60,6 +61,19 @@ module FeatureFlagger
       def released_to_all?(*feature_key)
         feature = Feature.new(feature_key, rollout_resource_name)
         FeatureFlagger.control.released_to_all?(feature.key)
+      end
+
+      def removed_rollouts
+        persisted = FeatureFlagger.control.search_keys("#{rollout_resource_name}:*").to_a
+        persisted - rollout_keys
+      end
+
+      def rollout_keys
+        keys = []
+        FeatureFlagger.config.info[rollout_resource_name].map do |namespace, features|
+          features.keys.each { |feature| keys.push("#{rollout_resource_name}:#{namespace}:#{feature}") }
+        end
+        keys
       end
 
       def rollout_resource_name

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -69,10 +69,11 @@ module FeatureFlagger
         (persisted_features - mapped_feature_keys).map { |key| key.sub("#{rollout_resource_name}:",'') }
       end
 
-      def remove_detached_feature_key(key)
-        key_value = FeatureFlagger.config.info[rollout_resource_name].dig(*key.split(":"))
+      def cleanup_detached(*feature_key)
+        complete_feature_key = feature_key.map(&:to_s).insert(0, rollout_resource_name)
+        key_value = FeatureFlagger.config.info.dig(*complete_feature_key)
         raise "key is still mapped" if key_value
-        FeatureFlagger.control.unrelease_to_all("#{rollout_resource_name}:#{key}")
+        FeatureFlagger.control.unrelease_to_all(complete_feature_key.join(':'))
       end
 
       def rollout_resource_name

--- a/lib/feature_flagger/storage/redis.rb
+++ b/lib/feature_flagger/storage/redis.rb
@@ -46,6 +46,10 @@ module FeatureFlagger
       def all_values(key)
         @redis.smembers(key)
       end
+
+      def search_keys(query)
+        @redis.scan_each(match: query)
+      end
     end
   end
 end

--- a/spec/feature_flagger/configuration_spec.rb
+++ b/spec/feature_flagger/configuration_spec.rb
@@ -21,5 +21,38 @@ module FeatureFlagger
         end
       end
     end
+
+    describe 'mapped_feature_keys' do
+      let(:configuration) { described_class.new }
+
+      before do
+        filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
+        configuration.yaml_filepath = filepath
+      end
+
+      context 'without resource name' do
+        it 'returns all mapped features keys' do
+          expect(configuration.mapped_feature_keys).to contain_exactly(
+            'feature_flagger_dummy_class:email_marketing:behavior_score',
+            'feature_flagger_dummy_class:email_marketing:whitelabel',
+            'other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_1',
+            'other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_2',
+            'other_feature_flagger_dummy_class:feature_b',
+            'other_feature_flagger_dummy_class:feature_c:feature_c_1',
+            'other_feature_flagger_dummy_class:feature_c:feature_c_2',
+            'other_feature_flagger_dummy_class:feature_c:feature_c_3:feature_c_3_1:feature_c_3_1_1'
+          )
+        end
+      end
+
+      context 'with resource name' do
+        it 'returns mapped features keys for feature_flagger_dummy_class resource' do
+          expect(configuration.mapped_feature_keys('feature_flagger_dummy_class')).to contain_exactly(
+            'feature_flagger_dummy_class:email_marketing:behavior_score',
+            'feature_flagger_dummy_class:email_marketing:whitelabel'
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -20,16 +20,19 @@ module FeatureFlagger
 
         context 'and a feature is release to all' do
           before { storage.add(FeatureFlagger::Control::RELEASED_FEATURES, key) }
+
           it { expect(result).to be_truthy }
         end
       end
 
       context 'when resource entity id has access to release_key' do
         before { storage.add(key, resource_id) }
+
         it { expect(result).to be_truthy }
 
         context 'and a feature is release to all' do
           before { storage.add(FeatureFlagger::Control::RELEASED_FEATURES, key) }
+
           it { expect(result).to be_truthy }
         end
       end
@@ -81,7 +84,7 @@ module FeatureFlagger
         control.release(key, 1)
         control.release(key, 2)
         control.release(key, 15)
-        is_expected.to match_array %w(1 2 15)
+        expect(subject).to match_array %w[1 2 15]
       end
     end
 
@@ -92,7 +95,7 @@ module FeatureFlagger
         control.release(FeatureFlagger::Control::RELEASED_FEATURES, 'feature::name1')
         control.release(FeatureFlagger::Control::RELEASED_FEATURES, 'feature::name2')
         control.release(FeatureFlagger::Control::RELEASED_FEATURES, 'feature::name15')
-        is_expected.to match_array %w(feature::name1 feature::name2 feature::name15)
+        expect(subject).to match_array %w[feature::name1 feature::name2 feature::name15]
       end
     end
 
@@ -101,12 +104,30 @@ module FeatureFlagger
 
       context 'when feature was not released to all' do
         before { storage.remove(FeatureFlagger::Control::RELEASED_FEATURES, key) }
-        it { expect(result).to be_falsey}
+
+        it { expect(result).to be_falsey }
       end
 
       context 'when feature was released to all' do
         before { storage.add(FeatureFlagger::Control::RELEASED_FEATURES, key) }
-        it { expect(result).to be_truthy}
+
+        it { expect(result).to be_truthy }
+      end
+    end
+
+    describe '#search_keys' do
+      before do
+        storage.add('namespace:1', 1)
+        storage.add('namespace:2', 2)
+        storage.add('exclusive', 3)
+      end
+
+      context 'without matching result' do
+        it { expect(control.search_keys('invalid').to_a).to be_empty }
+      end
+
+      context 'with matching results' do
+        it { expect(control.search_keys("*ame*pac*").to_a).to contain_exactly('namespace:1', 'namespace:2') }
       end
     end
   end

--- a/spec/feature_flagger/manager_spec.rb
+++ b/spec/feature_flagger/manager_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+module FeatureFlagger
+  RSpec.describe Manager do
+    describe 'mapped_feature_keys' do
+      let(:expected_features) do
+        [
+          "feature_flagger_dummy_class:email_marketing:behavior_score",
+          "feature_flagger_dummy_class:email_marketing:whitelabel",
+          "other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_1",
+          "other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_2",
+          "other_feature_flagger_dummy_class:feature_b",
+          "other_feature_flagger_dummy_class:feature_c:feature_c_1",
+          "other_feature_flagger_dummy_class:feature_c:feature_c_2",
+          "other_feature_flagger_dummy_class:feature_c:feature_c_3:feature_c_3_1:feature_c_3_1_1"
+        ]
+      end
+
+      before do
+        filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
+        FeatureFlagger.config.yaml_filepath = filepath
+      end
+
+      it 'returns all mapped features keys' do
+        expect(described_class.mapped_feature_keys).to eq expected_features
+      end
+    end
+
+    describe 'detached_feature_keys' do
+      let(:redis) { FakeRedis::Redis.new }
+      let(:storage) { Storage::Redis.new(redis) }
+      let(:feature_a_1_3) { "other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3" }
+      let(:feature_d) { "other_feature_flagger_dummy_class:feature_d" }
+
+      before do
+        FeatureFlagger.configure do |config|
+          config.storage = storage
+        end
+        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_1", 0)
+        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_2", 0)
+        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3", 0)
+        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_b", 0)
+        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_d", 0)
+
+        filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
+        FeatureFlagger.config.yaml_filepath = filepath
+      end
+
+      it 'returns all detached feature keys' do
+        expect(described_class.detached_feature_keys).to include feature_a_1_3, feature_d
+      end
+    end
+
+    describe 'remove_feature_key' do
+      let(:redis) { FakeRedis::Redis.new }
+      let(:storage) { Storage::Redis.new(redis) }
+      let(:feature_key) { "other_feature_flagger_dummy_class:feature_d" }
+
+      before do
+        FeatureFlagger.configure do |config|
+          config.storage = storage
+        end
+        FeatureFlagger.control.release(feature_key, 0)
+
+        filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
+        FeatureFlagger.config.yaml_filepath = filepath
+      end
+
+      it 'remove key' do
+        described_class.remove_feature_key(feature_key)
+        expect(described_class.detached_feature_keys).not_to include feature_key
+      end
+    end
+  end
+end

--- a/spec/feature_flagger/manager_spec.rb
+++ b/spec/feature_flagger/manager_spec.rb
@@ -2,73 +2,62 @@ require 'spec_helper'
 
 module FeatureFlagger
   RSpec.describe Manager do
-    describe 'mapped_feature_keys' do
-      let(:expected_features) do
-        [
-          "feature_flagger_dummy_class:email_marketing:behavior_score",
-          "feature_flagger_dummy_class:email_marketing:whitelabel",
-          "other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_1",
-          "other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_2",
-          "other_feature_flagger_dummy_class:feature_b",
-          "other_feature_flagger_dummy_class:feature_c:feature_c_1",
-          "other_feature_flagger_dummy_class:feature_c:feature_c_2",
-          "other_feature_flagger_dummy_class:feature_c:feature_c_3:feature_c_3_1:feature_c_3_1_1"
-        ]
-      end
-
-      before do
-        filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
-        FeatureFlagger.config.yaml_filepath = filepath
-      end
-
-      it 'returns all mapped features keys' do
-        expect(described_class.mapped_feature_keys).to eq expected_features
-      end
-    end
-
     describe 'detached_feature_keys' do
       let(:redis) { FakeRedis::Redis.new }
       let(:storage) { Storage::Redis.new(redis) }
-      let(:feature_a_1_3) { "other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3" }
-      let(:feature_d) { "other_feature_flagger_dummy_class:feature_d" }
 
       before do
         FeatureFlagger.configure do |config|
           config.storage = storage
         end
-        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_1", 0)
-        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_2", 0)
-        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3", 0)
-        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_b", 0)
-        FeatureFlagger.control.release("other_feature_flagger_dummy_class:feature_d", 0)
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_1', 0)
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_2', 0)
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3', 0)
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_b', 0)
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_d', 0)
 
         filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
         FeatureFlagger.config.yaml_filepath = filepath
       end
 
       it 'returns all detached feature keys' do
-        expect(described_class.detached_feature_keys).to include feature_a_1_3, feature_d
+        expect(described_class.detached_feature_keys).to include(
+          'other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3',
+          'other_feature_flagger_dummy_class:feature_d'
+        )
       end
     end
 
-    describe 'remove_feature_key' do
-      let(:redis) { FakeRedis::Redis.new }
-      let(:storage) { Storage::Redis.new(redis) }
-      let(:feature_key) { "other_feature_flagger_dummy_class:feature_d" }
+    describe 'remove_detached_feature_key' do
+      context "detached feature key" do
+        let(:redis) { FakeRedis::Redis.new }
+        let(:storage) { Storage::Redis.new(redis) }
+        let(:feature_key) { 'other_feature_flagger_dummy_class:feature_d' }
 
-      before do
-        FeatureFlagger.configure do |config|
-          config.storage = storage
+        before do
+          FeatureFlagger.configure do |config|
+            config.storage = storage
+          end
+          FeatureFlagger.control.release(feature_key, 0)
+
+          filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
+          FeatureFlagger.config.yaml_filepath = filepath
         end
-        FeatureFlagger.control.release(feature_key, 0)
 
-        filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
-        FeatureFlagger.config.yaml_filepath = filepath
+        it 'remove key' do
+          described_class.remove_detached_feature_key(feature_key)
+          expect(described_class.detached_feature_keys).not_to include feature_key
+        end
       end
 
-      it 'remove key' do
-        described_class.remove_feature_key(feature_key)
-        expect(described_class.detached_feature_keys).not_to include feature_key
+      context "mapped feature key" do
+        it 'do not remove key' do
+          expect {
+            described_class.remove_detached_feature_key(
+              'feature_flagger_dummy_class:email_marketing:behavior_score'
+            )
+          }.to raise_error("key is still mapped")
+        end
       end
     end
   end

--- a/spec/feature_flagger/manager_spec.rb
+++ b/spec/feature_flagger/manager_spec.rb
@@ -28,7 +28,7 @@ module FeatureFlagger
       end
     end
 
-    describe 'remove_detached_feature_key' do
+    describe 'cleanup_detached' do
       context "detached feature key" do
         let(:redis) { FakeRedis::Redis.new }
         let(:storage) { Storage::Redis.new(redis) }
@@ -44,17 +44,24 @@ module FeatureFlagger
           FeatureFlagger.config.yaml_filepath = filepath
         end
 
-        it 'remove key' do
-          described_class.remove_detached_feature_key(feature_key)
+        it 'cleanup key' do
+          described_class.cleanup_detached(
+            :other_feature_flagger_dummy_class, :feature_d
+          )
           expect(described_class.detached_feature_keys).not_to include feature_key
         end
       end
 
       context "mapped feature key" do
-        it 'do not remove key' do
+        before do
+          filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
+          FeatureFlagger.config.yaml_filepath = filepath
+        end
+
+        it 'do not cleanup key' do
           expect {
-            described_class.remove_detached_feature_key(
-              'feature_flagger_dummy_class:email_marketing:behavior_score'
+            described_class.cleanup_detached(
+              :feature_flagger_dummy_class, :email_marketing, :behavior_score
             )
           }.to raise_error("key is still mapped")
         end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -109,7 +109,7 @@ module FeatureFlagger
       end
     end
 
-    describe '.remove_detached_feature_key' do
+    describe '.cleanup_detached' do
 
       context "detached feature key" do
         let(:redis) { FakeRedis::Redis.new }
@@ -126,18 +126,16 @@ module FeatureFlagger
           FeatureFlagger.config.yaml_filepath = filepath
         end
 
-        it 'remove key' do
-          DummyClass.remove_detached_feature_key("feature_a")
+        it 'cleanup key' do
+          DummyClass.cleanup_detached(:feature_a)
           expect(DummyClass.detached_feature_keys).not_to include "feature_a"
         end
       end
 
       context "mapped feature key" do
-        it 'do not remove key' do
+        it 'do not cleanup key' do
           expect {
-            DummyClass.remove_detached_feature_key(
-              'email_marketing:behavior_score'
-            )
+            DummyClass.cleanup_detached(:email_marketing, :behavior_score)
           }.to raise_error("key is still mapped")
         end
       end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -88,5 +88,21 @@ module FeatureFlagger
         DummyClass.released_to_all?(key)
       end
     end
+
+    describe '.rollout_keys' do
+      it 'ensure retrieval of rollouts keys from file' do
+        expect(DummyClass.rollout_keys).to contain_exactly(
+          'feature_flagger_dummy_class:email_marketing:behavior_score',
+          'feature_flagger_dummy_class:email_marketing:whitelabel'
+        )
+      end
+    end
+
+    describe '.removed_rollouts' do
+      it 'calls Control#search_keys with appropriated methods' do
+        expect(control).to receive(:search_keys).with('feature_flagger_dummy_class:*')
+        DummyClass.removed_rollouts
+      end
+    end
   end
 end

--- a/spec/fixtures/rollout_example.yml
+++ b/spec/fixtures/rollout_example.yml
@@ -4,5 +4,21 @@ feature_flagger_dummy_class:
       description: "Enable behavior score experiment"
     whitelabel:
       description: "Enables whitelabel"
-
-
+other_feature_flagger_dummy_class:
+  feature_a:
+    feature_a_1:
+      feature_a_1_1:
+        description: "Key to test rollout with n levels"
+      feature_a_1_2:
+        description: "Key to test rollout with n levels"
+  feature_b:
+    description: "Key to test rollout with n levels"
+  feature_c:
+    feature_c_1:
+      description: "Key to test rollout with n levels"
+    feature_c_2:
+      description: "Key to test rollout with n levels"
+    feature_c_3:
+      feature_c_3_1:
+        feature_c_3_1_1:
+          description: "Key to test rollout with n levels"


### PR DESCRIPTION
## Problema
Quando uma feature é removida do arquivo de configuração e ela ainda possui registros salvos no storage, não é mais possível fazer a remoção deste registro através de uma chamada da própria API do feature flagger.
Esse problema foi reportado na issue #36 

## Solução
A solução proposta nesse PR considerou alguns pontos.
- O unrelease feito hoje é uma ação manual, o que permite que com o tempo venha a existir vários registros no storage não sincronizados com o arquivo de configuração. Isso acontece sempre que um dev remove uma feature e não faz um unrelease antes de atualizar a versão em produção. Para "lembrar" depois quais features foram removidas o dev terá que recorrer ao histórico do git para encontrar quais foram as features removidas do arquivo de configuração.
- O arquivo de configuração pode conter features relacionadas a várias "models" do sistema, então para identificar quais "features" não existentes no arquivo de configuração ainda estão persistidas no storage é necessário que o dev possa buscar por model ou de maneira geral, para não obrigar o dev ter que fazer várias buscas por várias models.
- A configuração a ser respeitada deve ser a existente no arquivo de configuração. Neste caso todo registro persistido no storage que não constar no arquivo de configuração é considerado um "lixo".
- A ação de remoção de um registro desvinculado da configuração deve ser "explicita", ou seja, o dev deve executar uma chamada de método explicitando qual feature deseja remover, isso porque fazer essa ação de forma automática tem um risco com relação ao feature_flagger estar conectado a um mesmo storage/namespace. Supomos que quem usa o feature flagger tem duas apps usando mesmo storage/namespace. Cada app terá um arquivo de configuração com as features. Então uma ação automática de remoção poderia apagar informações que não deveriam ser removidas. Claro que o ideal é que não se use o mesmo storage/namespace. Mas por hora a opção foi então fazer com que seja executado uma ação explicitando a remoção e qual registro se deseja remover. 

### Como solução foi incluído:
#### Na model
- Método na model para listar os registros "soltos" no storage.
```
Account.detached_feature_keys
retorno:
['email_marketing:alternative_email_flow']
```

- Método para remover um registro vinculado a model. Nesse caso como a feature não existe mais no arquivo de configuração é necessário informar a chave completa. O método valida se a chave não está no arquivo de configuração.
```
Account.cleanup_detached(:email_marketing, :alternative_email_flow)
```

#### Em um "Manager"
- Foi criado uma classe geral para fazer ações independentes da model

- Método no manager para listar os registros "soltos" no storage, independente de model
```
FeatureFlagger::Manager.detached_feature_keys
retorno:
['account:email_marketing:alternative_email_flow']
```

- Método para remover um registro. Nesse caso como a feature não existe mais no arquivo de configuração é necessário informar a chave completa. O método valida se a chave não está no arquivo de configuração.
```
FeatureFlagger::Manager.cleanup_detached(:account, :email_marketing, :alternative_email_flow)
```
