### PR TITLE
Fix Migration and .releases bugs

### DIFF
--- a/lib/feature_flagger/storage/feature_keys_migration.rb
+++ b/lib/feature_flagger/storage/feature_keys_migration.rb
@@ -48,7 +48,9 @@ module FeatureFlagger
         def migrate_release(key)
           resource_ids = @from_redis.smembers(key)
 
-          @to_control.release(key, resource_ids)
+          resource_ids.each do |id|
+            @to_control.release(key, id)
+          end
         end
       end
     end

--- a/lib/feature_flagger/storage/redis.rb
+++ b/lib/feature_flagger/storage/redis.rb
@@ -21,7 +21,9 @@ module FeatureFlagger
 
       def fetch_releases(resource_name, resource_id, global_key)
         resource_key = resource_key(resource_name, resource_id)
-        @redis.sunion(resource_key, global_key)
+        releases = @redis.sunion(resource_key, global_key)
+
+        releases.select{ |release| release.start_with?(resource_name) }
       end
 
       def has_value?(key, value)

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -50,6 +50,15 @@ module FeatureFlagger
       it 'return all releases to a given resource' do
         control.release(key, resource_id)
         resource_name = 'account'
+
+        expect(control.releases(resource_name, resource_id)).to match_array(['account:email_marketing:whitelabel'])
+      end
+
+      it 'does not return releases from another resource' do
+        control.release(key, resource_id)
+        control.release_to_all('user:another_rollout:global_whitelabel')
+        resource_name = 'account'
+
         expect(control.releases(resource_name, resource_id)).to match_array(['account:email_marketing:whitelabel'])
       end
     end

--- a/spec/feature_flagger/storage/feature_keys_migration_spec.rb
+++ b/spec/feature_flagger/storage/feature_keys_migration_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe FeatureFlagger::Storage::FeatureKeysMigration do
       end
 
       it 'does not migrate internal keys' do
-        expect(redis.keys.count).to eq(8)
+        expect(redis.keys.count).to eq(7)
       end
 
       it 'migrates all released feature keys to the new format ' do

--- a/spec/feature_flagger/storage/feature_keys_migration_spec.rb
+++ b/spec/feature_flagger/storage/feature_keys_migration_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe FeatureFlagger::Storage::FeatureKeysMigration do
         redis.sadd('feature_flagger_dummy_class:email_marketing:behavior_score', 42)
         redis.sadd('feature_flagger_dummy_class:email_marketing:whitelabel', 42)
         redis.sadd('feature_flagger_dummy_class:email_marketing:whitelabel', 1)
-        redis.sadd(global_key, 'feature_flagger_dummy_class:email_marketing:whitelabel')
+        redis.sadd(global_key, 'feature_flagger_dummy_class:email_marketing:global_whitelabel')
 
         control.release('other_feature_flagger_dummy_class:feature_b', 42)
         control.release_to_all('other_feature_flagger_dummy_class:feature_c:feature_c_1')
@@ -58,14 +58,21 @@ RSpec.describe FeatureFlagger::Storage::FeatureKeysMigration do
         expect(control.released?('feature_flagger_dummy_class:email_marketing:whitelabel', 42)).to be_truthy
         expect(control.released?('feature_flagger_dummy_class:email_marketing:whitelabel', 1)).to be_truthy
         expect(control.released?('other_feature_flagger_dummy_class:feature_b', 42)).to be_truthy
+
+        expect(control.releases('feature_flagger_dummy_class', 1)).to eq(
+          [
+            'feature_flagger_dummy_class:email_marketing:whitelabel',
+            'feature_flagger_dummy_class:email_marketing:global_whitelabel'
+          ]
+        )
       end
 
       it 'does not migrate internal keys' do
-        expect(redis.keys.count).to eq(7)
+        expect(redis.keys.count).to eq(8)
       end
 
       it 'migrates all released feature keys to the new format ' do
-        expect(control.released_to_all?('feature_flagger_dummy_class:email_marketing:whitelabel')).to be_truthy
+        expect(control.released_to_all?('feature_flagger_dummy_class:email_marketing:global_whitelabel')).to be_truthy
         expect(control.released_to_all?('other_feature_flagger_dummy_class:feature_c:feature_c_1')).to be_truthy
       end
     end

--- a/spec/feature_flagger/storage/feature_keys_migration_spec.rb
+++ b/spec/feature_flagger/storage/feature_keys_migration_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe FeatureFlagger::Storage::FeatureKeysMigration do
         expect(control.released?('feature_flagger_dummy_class:email_marketing:whitelabel', 1)).to be_truthy
         expect(control.released?('other_feature_flagger_dummy_class:feature_b', 42)).to be_truthy
 
-        expect(control.releases('feature_flagger_dummy_class', 1)).to eq(
+        expect(control.releases('feature_flagger_dummy_class', 1)).to match_array(
           [
             'feature_flagger_dummy_class:email_marketing:whitelabel',
             'feature_flagger_dummy_class:email_marketing:global_whitelabel'


### PR DESCRIPTION
* `.releases` shoul only return rollouts related to the resource.

* The migration is not writing the new format of `model:id` correctly