### PR TITLE
Fix detached_feature_keys bug

### DIFF
--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -59,7 +59,7 @@ module FeatureFlagger
     end
 
     def feature_keys
-      @storage.feature_keys
+      @storage.feature_keys - [FeatureFlagger::Control::RELEASED_FEATURES]
     end
   end
 end

--- a/lib/feature_flagger/manager.rb
+++ b/lib/feature_flagger/manager.rb
@@ -5,7 +5,7 @@ module FeatureFlagger
       persisted_features = FeatureFlagger.control.feature_keys
       mapped_feature_keys = FeatureFlagger.config.mapped_feature_keys
 
-      persisted_features - mapped_feature_keys - [FeatureFlagger::Control::RELEASED_FEATURES]
+      persisted_features - mapped_feature_keys
     end
 
     def self.cleanup_detached(resource_name, *feature_key)

--- a/lib/feature_flagger/manager.rb
+++ b/lib/feature_flagger/manager.rb
@@ -4,8 +4,8 @@ module FeatureFlagger
     def self.detached_feature_keys
       persisted_features = FeatureFlagger.control.feature_keys
       mapped_feature_keys = FeatureFlagger.config.mapped_feature_keys
-      
-      persisted_features - mapped_feature_keys
+
+      persisted_features - mapped_feature_keys - [FeatureFlagger::Control::RELEASED_FEATURES]
     end
 
     def self.cleanup_detached(resource_name, *feature_key)

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -146,5 +146,15 @@ module FeatureFlagger
         it { expect(control.search_keys("*ame*pac*").to_a).to contain_exactly('namespace:1', 'namespace:2') }
       end
     end
+
+    describe '#feature_keys' do
+      it 'returns only feature keys in storage' do
+        another_key = "account:some_other_feature"
+        control.release(key, resource_id)
+        control.release_to_all(another_key)
+
+        expect(control.feature_keys).to match_array([key])
+      end
+    end
   end
 end

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 module FeatureFlagger
   RSpec.describe Control do
     let(:redis) { FakeRedis::Redis.new }
-    let(:storage) { Storage::Redis.new(redis) }
-    let(:control) { Control.new(storage) }
+    let(:control) { Control.new(Storage::Redis.new(redis)) }
     let(:key)         { 'account:email_marketing:whitelabel' }
     let(:resource_id) { 'resource_id' }
     let(:resource_name) { 'account' }
@@ -65,33 +64,33 @@ module FeatureFlagger
 
     describe '#release_to_all' do
       it 'adds feature_key to storage' do
-        storage.add(key, resource_name, 1)
+        control.release(key, resource_id)
         control.release_to_all(key)
-        expect(storage).not_to have_value(key, 1)
-        expect(storage).to have_value(FeatureFlagger::Control::RELEASED_FEATURES, key)
+        expect(control.releases(resource_name, 1)).to include(key)
+        expect(control.released_features_to_all).to include(key)
       end
     end
 
     describe '#unrelease' do
       it 'removes resource_id from storage' do
-        storage.add(key, resource_name, resource_id)
+        control.release(key, resource_id)
         control.unrelease(key, resource_id)
-        expect(storage).not_to have_value(key, resource_id)
+        expect(control.released?(key, resource_id)).to be_falsey
       end
     end
 
     describe '#unrelease_to_all' do
       it 'removes feature_key to storage' do
-        storage.add(FeatureFlagger::Control::RELEASED_FEATURES, resource_name, key)
+        control.release_to_all(key)
         control.unrelease_to_all(key)
-        expect(storage).not_to have_value(FeatureFlagger::Control::RELEASED_FEATURES, key)
+        expect(control.released_features_to_all).not_to include(key)
       end
 
       it 'removes added resources' do
-        storage.add(key, resource_name, 1)
+        control.release(key, 1)
         control.unrelease_to_all(key)
-        expect(storage).not_to have_value(key, 1)
-        expect(storage).not_to have_value(FeatureFlagger::Control::RELEASED_FEATURES, key)
+        expect(control.released?(key, 1)).to be_falsey
+        expect(control.released_features_to_all).not_to include(key)
       end
     end
 
@@ -125,7 +124,7 @@ module FeatureFlagger
       end
 
       context 'when feature was released to all' do
-        before { storage.add_all(FeatureFlagger::Control::RELEASED_FEATURES, key) }
+        before { control.release_to_all(key) }
 
         it { expect(result).to be_truthy }
       end
@@ -133,9 +132,9 @@ module FeatureFlagger
 
     describe '#search_keys' do
       before do
-        storage.add('namespace:1', resource_name, 1)
-        storage.add('namespace:2', resource_name, 2)
-        storage.add('exclusive', resource_name, 3)
+        control.release("model:namespace:1", 1)
+        control.release("model:namespace:2", 2)
+        control.release("model:exclusive", 3)
       end
 
       context 'without matching result' do
@@ -143,7 +142,7 @@ module FeatureFlagger
       end
 
       context 'with matching results' do
-        it { expect(control.search_keys("*ame*pac*").to_a).to contain_exactly('namespace:1', 'namespace:2') }
+        it { expect(control.search_keys("*ame*pac*").to_a).to contain_exactly('model:namespace:1', 'model:namespace:2') }
       end
     end
 

--- a/spec/feature_flagger/manager_spec.rb
+++ b/spec/feature_flagger/manager_spec.rb
@@ -10,14 +10,19 @@ module FeatureFlagger
         FeatureFlagger.configure do |config|
           config.storage = storage
         end
-        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_1', 0)
-        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_2', 0)
-        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3', 0)
-        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_b', 0)
-        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_d', 0)
 
         filepath = File.expand_path('../../fixtures/rollout_example.yml', __FILE__)
         FeatureFlagger.config.yaml_filepath = filepath
+
+        # All good here
+        FeatureFlagger.control.release_to_all('feature_flagger_dummy_class:email_marketing:behavior_score')
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_1', 0)
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_2', 0)
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_b', 0)
+
+        # Detached keys
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3', 0)
+        FeatureFlagger.control.release('other_feature_flagger_dummy_class:feature_d', 0)
       end
 
       it 'returns all detached feature keys' do


### PR DESCRIPTION
Why?

`detached_feature_keys` is wrongly returning the `released_features` key, making the use of this method dangerous.


```
  1) FeatureFlagger::Manager detached_feature_keys returns all detached feature keys
     Failure/Error:
       expect(described_class.detached_feature_keys).to match_array([
         'other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3',
         'other_feature_flagger_dummy_class:feature_d'
       ])
     
       expected collection contained:  ["other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3", "other_feature_flagger_dummy_class:feature_d"]
       actual collection contained:    ["other_feature_flagger_dummy_class:feature_a:feature_a_1:feature_a_1_3", "other_feature_flagger_dummy_class:feature_d", "released_features"]
       the extra elements were:        ["released_features"]
     # ./spec/feature_flagger/manager_spec.rb:29:in `block (3 levels) in <module:FeatureFlagger>'
```