### PR TITLE
Releasing new version after reverting 2.0.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2021-01-27
+
+- Reverted 2.0.0 because of some issues with Redis Keys.
+
+## [2.0.0] - 2020-06-15
+
+* This version has some issues with Redis Keys. Use version 2.0.1 or 1.2.1.*
+
+### Added
+- A new structure of data inside Storage::Redis #60
+- This CHANGELOG file to hopefully serve as an evolving example of a
+  standardized open-source project CHANGELOG.
+- New `Model#releases` method, which will return all the features accessible by the `Model`
+
+### Breaking Changes
+- The main API of `FeatureFlagger::Control` and `FeatureFlagger::Storage`
+  got rewritten, we decoupled the `resource_name` from the `feature_key`
+  and that allowed us to change the way we store the data
 
 ## [1.2.1] - 2020-08-10
 ### Added

--- a/lib/feature_flagger/version.rb
+++ b/lib/feature_flagger/version.rb
@@ -1,4 +1,3 @@
 module FeatureFlagger
-  VERSION = "1.3.0"
+  VERSION = "2.0.1"
 end
-


### PR DESCRIPTION
After the PR [#66](https://github.com/ResultadosDigitais/feature_flagger/pull/66), no new version was released and some users maybe are using the buggy 2.0 version that is published at Ruby gems.