### PR TITLE
Adding a cache layer for avoiding to hit the storage - Saving network roundtrips

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+- Add integration with ActionSupport::Cache's stores. As rollouts don't change often, adding a cache can save thousands of calls to the storage. It's possible to configure the same way Rails allows cache_stores to be configured.
+
+  configuration.cache_store = :memory_store, { expires_in: 100 }
+
+  Additionally, we also added an option to skip the cache entirely by adding a `skip_cache: true` on FF methods. Example:
+
+  Account.released_id?(resource_id, key, skip_local_cache: true)
+
+  By default there is no cache configured.
+
+
 ## [2.0.1] - 2021-01-27
 
 - Reverted 2.0.0 because of some issues with Redis Keys.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ FeatureFlagger.configure do |config|
 end
 ```
 
+It's also possible to configure an additional cache layer by using ActiveSupport::Cache APIs. You can configure it the same way you would setup cache_store for Rails Apps. Caching is not enabled by default.
+
+
+```ruby
+configuration.cache_store = :memory_store, { expires_in: 100 }
+
+```
+
+
 1. Create a `rollout.yml` in _config_ path and declare a rollout:
 ```yml
 account: # model name
@@ -96,6 +105,10 @@ account.release(:email_marketing, :new_email_flow)
 account.released?(:email_marketing, :new_email_flow)
 #=> true
 
+# In order to bypass the cache if cache_store is configured
+account.released?(:email_marketing, :new_email_flow, skip_cache: true)
+#=> true
+
 # Remove feature for given account
 account.unrelease(:email_marketing, :new_email_flow)
 #=> true
@@ -106,6 +119,10 @@ FeatureFlagger::KeyNotFoundError: ["account", "email_marketing", "new_email_flo"
 
 # Check feature for a specific account id
 Account.released_id?(42, :email_marketing, :new_email_flow)
+#=> true
+
+# In order to bypass the cache if cache_store is configured
+Account.released_id?(42, :email_marketing, :new_email_flow, skip_cache: true)
 #=> true
 
 # Release a feature for a specific account id
@@ -123,6 +140,10 @@ Account.unrelease_to_all(:email_marketing, :new_email_flow)
 
 # Return an array with all features released for all
 Account.released_features_to_all
+
+# In order to bypass the cache if cache_store is configured
+Account.released_features_to_all(skip_cache: true)
+
 ```
 
 ## Clean up action

--- a/feature_flagger.gemspec
+++ b/feature_flagger.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'redis', '> 3.2'
   spec.add_dependency 'redis-namespace', '> 1.3'
+  spec.add_development_dependency 'activesupport', '> 6.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/lib/feature_flagger.rb
+++ b/lib/feature_flagger.rb
@@ -30,7 +30,7 @@ module FeatureFlagger
     end
 
     def control
-      @@control ||= Control.new(config.storage, notifier)
+      @@control ||= Control.new(config.storage, notifier, config.cache_store)
     end
   end
 end

--- a/lib/feature_flagger/configuration.rb
+++ b/lib/feature_flagger/configuration.rb
@@ -1,11 +1,17 @@
 module FeatureFlagger
   class Configuration
-    attr_accessor :storage, :yaml_filepath, :notifier_callback
+    attr_accessor :storage, :cache_store, :yaml_filepath, :notifier_callback
 
     def initialize
       @storage       ||= Storage::Redis.default_client
       @yaml_filepath ||= default_yaml_filepath
       @notifier_callback = nil
+      @cache_store = nil
+    end
+
+    def cache_store=(cache_store)
+      raise ArgumentError, "Cache is only support when used with ActiveSupport" unless defined?(ActiveSupport)
+      @cache_store = ActiveSupport::Cache.lookup_store(*cache_store)
     end
 
     def info

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -4,13 +4,16 @@ module FeatureFlagger
 
     RELEASED_FEATURES = 'released_features'
 
-    def initialize(storage, notifier)
+    def initialize(storage, notifier, cache_store = nil)
       @storage = storage
       @notifier = notifier
+      @cache_store = cache_store
     end
 
-    def released?(feature_key, resource_id)
-      @storage.has_value?(RELEASED_FEATURES, feature_key) || @storage.has_value?(feature_key, resource_id)
+    def released?(feature_key, resource_id, options = {})
+      cache "released/#{feature_key}", options do
+        @storage.has_value?(RELEASED_FEATURES, feature_key) || @storage.has_value?(feature_key, resource_id)
+      end
     end
 
     def release(feature_key, resource_id)
@@ -22,8 +25,10 @@ module FeatureFlagger
       @storage.add(feature_key, resource_name, resource_id)
     end
 
-    def releases(resource_name, resource_id)
-      @storage.fetch_releases(resource_name, resource_id, RELEASED_FEATURES)
+    def releases(resource_name, resource_id, options = {})
+      cache "releases/#{RELEASED_FEATURES}", options do
+        @storage.fetch_releases(resource_name, resource_id, RELEASED_FEATURES)
+      end
     end
 
     def release_to_all(feature_key)
@@ -44,16 +49,22 @@ module FeatureFlagger
       @storage.remove_all(RELEASED_FEATURES, feature_key)
     end
 
-    def resource_ids(feature_key)
-      @storage.all_values(feature_key)
+    def resource_ids(feature_key, options = {})
+      cache "all_values/#{feature_key}", options do
+        @storage.all_values(feature_key)
+      end
     end
 
-    def released_features_to_all
-      @storage.all_values(RELEASED_FEATURES)
+    def released_features_to_all(options = {})
+      cache "all_values/#{RELEASED_FEATURES}", options do
+        @storage.all_values(RELEASED_FEATURES)
+      end
     end
 
-    def released_to_all?(feature_key)
-      @storage.has_value?(RELEASED_FEATURES, feature_key)
+    def released_to_all?(feature_key, options = {})
+      cache "has_value/#{RELEASED_FEATURES}", options do
+        @storage.has_value?(RELEASED_FEATURES, feature_key)
+      end
     end
 
     # DEPRECATED: this method will be removed from public api on v2.0 version.
@@ -65,5 +76,16 @@ module FeatureFlagger
     def feature_keys
       @storage.feature_keys - [FeatureFlagger::Control::RELEASED_FEATURES]
     end
+
+    def cache(name, options, &block)
+      if @cache_store
+        @cache_store.fetch(name, force: options[:skip_cache]) do
+          block.call
+        end
+      else
+        block.call
+      end
+    end
+
   end
 end

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -12,8 +12,8 @@ module FeatureFlagger
       base.extend ClassMethods
     end
 
-    def released?(*feature_key)
-      self.class.released_id?(feature_flagger_identifier, feature_key)
+    def released?(*feature_key, **options)
+      self.class.released_id?(feature_flagger_identifier, feature_key, options)
     end
 
     def release(*feature_key)
@@ -26,9 +26,9 @@ module FeatureFlagger
       FeatureFlagger.control.unrelease(feature.key, id)
     end
 
-    def releases
+    def releases(options = {})
       resource_name = self.class.feature_flagger_model_settings.entity_name
-      FeatureFlagger.control.releases(resource_name, id)
+      FeatureFlagger.control.releases(resource_name, id, options)
     end
 
     private
@@ -43,9 +43,9 @@ module FeatureFlagger
         yield feature_flagger_model_settings
       end
 
-      def released_id?(resource_id, *feature_key)
+      def released_id?(resource_id, *feature_key, **options)
         feature = Feature.new(feature_key, feature_flagger_model_settings.entity_name)
-        FeatureFlagger.control.released?(feature.key, resource_id)
+        FeatureFlagger.control.released?(feature.key, resource_id, options)
       end
 
       def release_id(resource_id, *feature_key)
@@ -58,10 +58,10 @@ module FeatureFlagger
         FeatureFlagger.control.unrelease(feature.key, resource_id)
       end
 
-      def all_released_ids_for(*feature_key)
+      def all_released_ids_for(*feature_key, **options)
         feature_key.flatten!
         feature = Feature.new(feature_key, feature_flagger_model_settings.entity_name)
-        FeatureFlagger.control.resource_ids(feature.key)
+        FeatureFlagger.control.resource_ids(feature.key, options)
       end
 
       def release_to_all(*feature_key)
@@ -74,13 +74,13 @@ module FeatureFlagger
         FeatureFlagger.control.unrelease_to_all(feature.key)
       end
 
-      def released_features_to_all
-        FeatureFlagger.control.released_features_to_all
+      def released_features_to_all(options = {})
+        FeatureFlagger.control.released_features_to_all(options)
       end
 
-      def released_to_all?(*feature_key)
+      def released_to_all?(*feature_key, **options)
         feature = Feature.new(feature_key, feature_flagger_model_settings.entity_name)
-        FeatureFlagger.control.released_to_all?(feature.key)
+        FeatureFlagger.control.released_to_all?(feature.key, options)
       end
 
       def detached_feature_keys

--- a/spec/feature_flagger/configuration_spec.rb
+++ b/spec/feature_flagger/configuration_spec.rb
@@ -22,6 +22,28 @@ module FeatureFlagger
       end
     end
 
+    describe '.cache_store' do
+      let(:configuration) { described_class.new }
+
+      context 'no cache_store set' do
+        it 'returns nil by default' do
+          expect(configuration.cache_store).to be_nil
+        end
+      end
+
+      context 'cache_store set to :memory_store' do
+        it 'returns an ActiveSupport::Cache::MemoryStore instance' do
+          configuration.cache_store = :memory_store
+          expect(configuration.cache_store).to be_an(ActiveSupport::Cache::MemoryStore)
+        end
+
+        it 'allows custom params' do
+          configuration.cache_store = :memory_store, { expires_in: 100 }
+          expect(configuration.cache_store.options[:expires_in]).to eq(100)
+        end
+      end
+    end
+
     describe 'mapped_feature_keys' do
       let(:configuration) { described_class.new }
 

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -27,7 +27,7 @@ module FeatureFlagger
     
     describe '#releases' do
       it 'calls Control#release with appropriated methods' do
-        expect(control).to receive(:releases).with("feature_flagger_dummy_class", subject.id)
+        expect(control).to receive(:releases).with("feature_flagger_dummy_class", subject.id, {})
         subject.releases
       end
     end
@@ -44,8 +44,13 @@ module FeatureFlagger
         let(:resource_id) { 10 }
 
         it 'calls Control#released? with appropriated methods' do
-          expect(control).to receive(:released?).with(resolved_key, resource_id)
+          expect(control).to receive(:released?).with(resolved_key, resource_id, {})
           DummyClass.released_id?(resource_id, key)
+        end
+
+        it 'passes down cache options to storage' do
+          expect(control).to receive(:released?).with(resolved_key, resource_id, { skip_cache: true })
+          DummyClass.released_id?(resource_id, key, skip_cache: true)
         end
       end
     end
@@ -74,8 +79,13 @@ module FeatureFlagger
 
     describe '.all_released_ids_for' do
       it 'calls Control#resource_ids with appropriated methods' do
-        expect(control).to receive(:resource_ids).with(resolved_key)
+        expect(control).to receive(:resource_ids).with(resolved_key, {})
         DummyClass.all_released_ids_for(key)
+      end
+
+      it 'passes down cache options to storage' do
+        expect(control).to receive(:resource_ids).with(resolved_key, { skip_cache: true})
+        DummyClass.all_released_ids_for(key, skip_cache: true)
       end
     end
 
@@ -102,7 +112,7 @@ module FeatureFlagger
 
     describe '.released_to_all?' do
       it 'calls Control#released_to_all? with appropriated methods' do
-        expect(control).to receive(:released_to_all?).with(resolved_key)
+        expect(control).to receive(:released_to_all?).with(resolved_key, {})
         DummyClass.released_to_all?(key)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,3 +13,4 @@ end
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'feature_flagger'
+require 'active_support'


### PR DESCRIPTION
High level config:

```
FeatureFlagger.configure do |config|
  redis = ::Redis::Namespace.new('feature-flagger-rollout-control', redis: RedisFactory.default_client)
  config.storage = FeatureFlagger::Storage::Redis.new(redis))
  config.cache_store = :memory_store, { expires_in: 10.minutes }
end
```

Cache Store is powered by ActiveSupport. So it works pretty much like https://guides.rubyonrails.org/caching_with_rails.html#cache-stores

The same options will apply. :file_store, :memory_store, etc