### PR TITLE
Loads NullStore when configuring cache_store explicit to nil.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+- Fix bug when configuring cache_key to nil would load MemoryStore by default. It returns NullStore now. This bug only affected users configuring cache_store to nil.
+- Configure cache_keys correctly
+
 ## [2.1.0] - 2021-06-30
 - Add integration with ActionSupport::Cache's stores. As rollouts don't change often, adding a cache can save thousands of calls to the storage. It's possible to configure the same way Rails allows cache_stores to be configured.
 

--- a/lib/feature_flagger/configuration.rb
+++ b/lib/feature_flagger/configuration.rb
@@ -11,7 +11,10 @@ module FeatureFlagger
 
     def cache_store=(cache_store)
       raise ArgumentError, "Cache is only support when used with ActiveSupport" unless defined?(ActiveSupport)
-      @cache_store = ActiveSupport::Cache.lookup_store(*cache_store)
+
+      if cache_store
+        @cache_store = ActiveSupport::Cache.lookup_store(*cache_store)
+      end
     end
 
     def info

--- a/lib/feature_flagger/configuration.rb
+++ b/lib/feature_flagger/configuration.rb
@@ -12,9 +12,8 @@ module FeatureFlagger
     def cache_store=(cache_store)
       raise ArgumentError, "Cache is only support when used with ActiveSupport" unless defined?(ActiveSupport)
 
-      if cache_store
-        @cache_store = ActiveSupport::Cache.lookup_store(*cache_store)
-      end
+      cache_store = :null_store if cache_store.nil?
+      @cache_store = ActiveSupport::Cache.lookup_store(*cache_store)
     end
 
     def info

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -11,7 +11,7 @@ module FeatureFlagger
     end
 
     def released?(feature_key, resource_id, options = {})
-      cache "released/#{feature_key}", options do
+      cache "released/#{feature_key}/#{resource_id}", options do
         @storage.has_value?(RELEASED_FEATURES, feature_key) || @storage.has_value?(feature_key, resource_id)
       end
     end
@@ -26,7 +26,7 @@ module FeatureFlagger
     end
 
     def releases(resource_name, resource_id, options = {})
-      cache "releases/#{RELEASED_FEATURES}", options do
+      cache "releases/#{resource_name}/#{resource_id}", options do
         @storage.fetch_releases(resource_name, resource_id, RELEASED_FEATURES)
       end
     end
@@ -56,13 +56,13 @@ module FeatureFlagger
     end
 
     def released_features_to_all(options = {})
-      cache "all_values/#{RELEASED_FEATURES}", options do
+      cache "released_features_to_all/#{RELEASED_FEATURES}", options do
         @storage.all_values(RELEASED_FEATURES)
       end
     end
 
     def released_to_all?(feature_key, options = {})
-      cache "has_value/#{RELEASED_FEATURES}", options do
+      cache "has_value/#{RELEASED_FEATURES}/#{feature_key}", options do
         @storage.has_value?(RELEASED_FEATURES, feature_key)
       end
     end

--- a/spec/feature_flagger/configuration_spec.rb
+++ b/spec/feature_flagger/configuration_spec.rb
@@ -31,6 +31,13 @@ module FeatureFlagger
         end
       end
 
+      context 'cache_store set to :null_store when explicit set to nil' do
+        it 'returns an ActiveSupport::Cache::NullStore instance' do
+          configuration.cache_store = nil
+          expect(configuration.cache_store).to be_an(ActiveSupport::Cache::NullStore)
+        end
+      end
+
       context 'cache_store set to :memory_store' do
         it 'returns an ActiveSupport::Cache::MemoryStore instance' do
           configuration.cache_store = :memory_store


### PR DESCRIPTION
- When configuring cache_key to nil would load MemoryStore by default. it returns NullStore now. This bug only affected users configuring cache_store to nil.
- Configure cache_keys correctly (my mistake)