### PR TITLE
Switch to newer generation of CircleCi images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
   coverage:
     docker:
-      - image: circleci/ruby:2.5.8
+      - image: cimg/ruby:2.5.8
         environment:
           COVERAGE: true
     steps:


### PR DESCRIPTION
Current images have reached end of life https://circleci.com/docs/2.0/next-gen-migration-guide/