### PR TITLE
Add new methods to get rollout details

### DIFF
--- a/lib/feature_flagger/feature.rb
+++ b/lib/feature_flagger/feature.rb
@@ -10,6 +10,18 @@ module FeatureFlagger
       @data['description']
     end
 
+    def created_at
+      @data['created_at']
+    end
+
+    def owner
+      @data['owner']
+    end
+
+    def full_rollout_until
+      @data['full_rollout_until']
+    end
+
     def key
       @feature_key.join(':')
     end

--- a/spec/feature_flagger/feature_spec.rb
+++ b/spec/feature_flagger/feature_spec.rb
@@ -34,6 +34,21 @@ module FeatureFlagger
       it { expect(subject.description).to eq 'Enable behavior score experiment' }
     end
 
+    describe '#created_at' do
+      let(:key) { [:email_marketing, :behavior_score] }
+      it { expect(subject.created_at).to eq("2019-05-31") }
+    end
+
+    describe '#owner' do
+      let(:key) { [:email_marketing, :behavior_score] }
+      it { expect(subject.owner).to eq("Team Name") }
+    end
+
+    describe '#full_rollout_until' do
+      let(:key) { [:email_marketing, :behavior_score] }
+      it { expect(subject.full_rollout_until).to eq("2020-12-31") }
+    end
+
     describe '#key' do
       let(:key)          { [:email_marketing, :behavior_score] }
       let(:resolved_key) { 'feature_flagger_dummy_class:email_marketing:behavior_score' }

--- a/spec/fixtures/rollout_example.yml
+++ b/spec/fixtures/rollout_example.yml
@@ -2,6 +2,9 @@ feature_flagger_dummy_class:
   email_marketing:
     behavior_score:
       description: "Enable behavior score experiment"
+      created_at: "2019-05-31"
+      full_rollout_until: "2020-12-31"
+      owner: "Team Name"
     whitelabel:
       description: "Enables whitelabel"
 other_feature_flagger_dummy_class:


### PR DESCRIPTION
## About
This PR adds **3 new methods** to the gem in order to get some rollout details:

`created_at `-> to know when the rollout was created
`full_rollout_until `-> to know when the rollout is supposed to be done
`owner `-> to know which is the team responsible for that specific rollout 

