### PR TITLE
add catalog info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: feature_flagger
+  description: Libere novos recursos para seus clientes de forma segura.
+  annotations:
+    circleci.com/project-slug: github/ResultadosDigitais/feature_flagger
+    github.com/project-slug: ResultadosDigitais/feature_flagger
+spec:
+  type: library
+  owner: devtools
+  lifecycle: production


### PR DESCRIPTION
**Contexto**

Estamos mapeando os componentes do plataform para dentro do Backstage e por isso precisamos deste arquivo yaml no mesmo diretório do componente para que ele seja refletido no Backstage.

É possível consultar mais detalhes deste mapeamento aqui: https://github.com/ResultadosDigitais/designdoc/blob/master/enablers/devtools/fonte-da-verdade-artefatos.md
