### PR TITLE
Lançamento de erros para operações nulas

### DIFF
--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -17,6 +17,7 @@ module FeatureFlagger
     end
 
     def release(*feature_key)
+      raise 'identifier cannot be null' if feature_flagger_identifier.nil?
       self.class.release_id(feature_flagger_identifier, *feature_key)
     end
 
@@ -49,6 +50,7 @@ module FeatureFlagger
       end
 
       def release_id(resource_id, *feature_key)
+        raise 'resource_id cannot be null' if resource_id.nil?
         feature = Feature.new(feature_key, feature_flagger_model_settings.entity_name)
         FeatureFlagger.control.release(feature.key, resource_id)
       end

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -4,7 +4,11 @@ module FeatureFlagger
 
   class DummyClass
     include FeatureFlagger::Model
-    def id; 14 end
+    attr :id
+
+    def initialize(id: 14)
+      @id = id
+    end
   end
 
   RSpec.describe Model do
@@ -22,6 +26,16 @@ module FeatureFlagger
       it 'calls Control#release with appropriated methods' do
         expect(control).to receive(:release).with(resolved_key, subject.id)
         subject.release(key)
+      end
+
+      context 'when subject has id nil' do
+        subject { DummyClass.new(id: nil) }
+
+        it 'raise error identifier cannot be null' do
+          expect{
+            subject.release(key)
+          }.to raise_error 'identifier cannot be null'
+        end
       end
     end
     
@@ -64,6 +78,12 @@ module FeatureFlagger
           DummyClass.release_id(resource_id, key)
         end
       end
+
+      it 'raise error identifier cannot be null' do
+        expect{
+          DummyClass.release_id(nil, key)
+        }.to raise_error 'resource_id cannot be null'
+        end
     end
 
     describe '.unrelease_id' do
@@ -165,6 +185,7 @@ module FeatureFlagger
             DummyClass.cleanup_detached(:email_marketing, :behavior_score)
           }.to raise_error("key is still mapped")
         end
+
       end
     end
 


### PR DESCRIPTION
# Problema

Atualmente se chamar `MyModel.release_id(nil, :my_flag, :a)` temos como resultado o rollout para todas as contas. Isso se torna ainda pior quando não estamos utilizando um identificador igual ao `id` que ao executar `my_instance_model.release(:my_flag, :a)` irá fazer rollout para todas as instancias.

# Solução

Aplicar validações e lançar erros quando operações nulas serem enviadas na camada de modelo.