### PR TITLE
Bugfix: The unrelease and release processes did not account for the specified feature_flagger_identifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
   coverage:
     docker:
-      - image: cimg/ruby:2.5.8
+      - image: cimg/ruby:3.3
         environment:
           COVERAGE: true
     steps:
@@ -39,5 +39,5 @@ workflows:
       - build:
           matrix:
             parameters:
-              ruby-version: ["circleci/ruby:2.5.8", "circleci/ruby:2.6.6", "circleci/ruby:2.7.4", "circleci/ruby:3.0.2"]
+              ruby-version: ["cimg/ruby:3.1", "cimg/ruby:3.2", "cimg/ruby:3.3"]
       - coverage

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -23,12 +23,12 @@ module FeatureFlagger
     def unrelease(*feature_key)
       resource_name = self.class.feature_flagger_model_settings.entity_name
       feature = Feature.new(feature_key, resource_name)
-      FeatureFlagger.control.unrelease(feature.key, id)
+      FeatureFlagger.control.unrelease(feature.key, feature_flagger_identifier)
     end
 
     def releases(options = {})
       resource_name = self.class.feature_flagger_model_settings.entity_name
-      FeatureFlagger.control.releases(resource_name, id, options)
+      FeatureFlagger.control.releases(resource_name, feature_flagger_identifier, options)
     end
 
     private

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -188,6 +188,9 @@ module FeatureFlagger
         expect(CustomizedDummyClass.all_released_ids_for(:email_marketing, :behavior_score)).to include(
           'f11bc560-8ef9-40cf-909e-ebb1c6f41163'
         )
+
+        CustomizedDummyClass.new.unrelease(:email_marketing, :behavior_score)
+        expect(CustomizedDummyClass.all_released_ids_for(:email_marketing, :behavior_score)).to be_empty
       end
     end
   end


### PR DESCRIPTION
This PR addresses a bug where model configurations were not considered during `unrelease` operations. Consider the following example:

```ruby
class User < ActiveRecord::Base
  include FeatureFlagger::Model

  feature_flagger do |config|
    config.identifier_field = :email
  end
end
```

While adding a user to the rollout works correctly, the `unrelease` operation does not. This issue arises because the `unrelease` operation uses the `id` as the `resource_id` instead of the specified `email` field.

### Testing

1. Install this patch into your current Rails project and add the following configuration to the User model:

```ruby
class User
  feature_flagger do |config|
    config.identifier_field = :email
  end
end
```

2. Access the Redis instance and execute the command `monitor`, then leave it running.

3. In the Rails console, execute `User.first.release(YOUR_ROLLOUT_KEY)`.

4. In the Rails console, after the previous step, when you type `User.first.released?(YOUR_ROLLOUT_KEY)`, it should return true.

5. In the Rails console, run `User.first.unrelease(YOUR_ROLLOUT_KEY)`.

6. In the Rails console, after the previous step, when you type `User.first.released?(YOUR_ROLLOUT_KEY)`, it should return false.

Expected Result:
When monitoring Redis, the value added to the underlying Redis SET should be an email, not the User ID.


