### PR TITLE
adds release count feature to model

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Account.released_features_to_all
 
 # Get the count of resource ids released
 Account.release_count(:email_marketing, :new_email_flow)
+#=> 30
 
 # In order to bypass the cache if cache_store is configured
 Account.released_features_to_all(skip_cache: true)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ account.unrelease(:email_marketing, :new_email_flow)
 
 # If you try to check an inexistent rollout key it will raise an error.
 account.released?(:email_marketing, :new_email_flow)
-FeatureFlagger::KeyNotFoundError: ["account", "email_marketing", "new_email_flo"]
+#=> FeatureFlagger::KeyNotFoundError: ["account", "email_marketing", "new_email_flo"]
 
 # Check feature for a specific account id
 Account.released_id?(42, :email_marketing, :new_email_flow)
@@ -144,9 +144,11 @@ Account.unrelease_to_all(:email_marketing, :new_email_flow)
 # Return an array with all features released for all
 Account.released_features_to_all
 
+# Get the count of resource ids released
+Account.release_count(:email_marketing, :new_email_flow)
+
 # In order to bypass the cache if cache_store is configured
 Account.released_features_to_all(skip_cache: true)
-
 ```
 
 ## Clean up action

--- a/lib/feature_flagger/control.rb
+++ b/lib/feature_flagger/control.rb
@@ -67,6 +67,10 @@ module FeatureFlagger
       end
     end
 
+    def release_count(feature_key)
+      @storage.count(feature_key)
+    end
+
     # DEPRECATED: this method will be removed from public api on v2.0 version.
     # use instead the feature_keys method.
     def search_keys(query)

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -31,6 +31,10 @@ module FeatureFlagger
       FeatureFlagger.control.releases(resource_name, feature_flagger_identifier, options)
     end
 
+    def released_count(*feature_key)
+      self.class.release_count(*feature_key)
+    end
+
     private
 
     def feature_flagger_identifier
@@ -51,6 +55,11 @@ module FeatureFlagger
       def release_id(resource_id, *feature_key)
         feature = Feature.new(feature_key, feature_flagger_model_settings.entity_name)
         FeatureFlagger.control.release(feature.key, resource_id)
+      end
+
+      def release_count(*feature_key)
+        feature = Feature.new(feature_key, feature_flagger_model_settings.entity_name)
+        FeatureFlagger.control.release_count(feature.key)
       end
 
       def unrelease_id(resource_id, *feature_key)

--- a/lib/feature_flagger/model.rb
+++ b/lib/feature_flagger/model.rb
@@ -31,10 +31,6 @@ module FeatureFlagger
       FeatureFlagger.control.releases(resource_name, feature_flagger_identifier, options)
     end
 
-    def released_count(*feature_key)
-      self.class.release_count(*feature_key)
-    end
-
     private
 
     def feature_flagger_identifier

--- a/lib/feature_flagger/storage/redis.rb
+++ b/lib/feature_flagger/storage/redis.rb
@@ -32,6 +32,10 @@ module FeatureFlagger
         @redis.sismember(key, value)
       end
 
+      def count(key)
+        @redis.scard(key)
+      end
+
       def add(feature_key, resource_name, resource_id)
         resource_key = resource_key(resource_name, resource_id)
 

--- a/spec/feature_flagger/control_spec.rb
+++ b/spec/feature_flagger/control_spec.rb
@@ -231,6 +231,17 @@ module FeatureFlagger
       end
     end
 
+    describe '#release_count' do
+      subject { control.release_count(key) }
+
+      it 'returns the number of resource_ids for the given feature_key' do
+        control.release(key, 1)
+        control.release(key, 2)
+        control.release(key, 15)
+        expect(subject).to eq(3)
+      end
+    end
+
     describe '#search_keys' do
       before do
         control.release("model:namespace:1", 1)

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -39,13 +39,6 @@ module FeatureFlagger
       end
     end
 
-    describe '#released_count' do
-      it 'calls Control#release_count with appropriated methods' do
-        expect(control).to receive(:release_count).with(resolved_key)
-        subject.released_count(key)
-      end
-    end
-
     describe '.released_id?' do
       context 'given a specific resource id' do
         let(:resource_id) { 10 }

--- a/spec/feature_flagger/model_spec.rb
+++ b/spec/feature_flagger/model_spec.rb
@@ -24,7 +24,7 @@ module FeatureFlagger
         subject.release(key)
       end
     end
-    
+
     describe '#releases' do
       it 'calls Control#release with appropriated methods' do
         expect(control).to receive(:releases).with("feature_flagger_dummy_class", subject.id, {})
@@ -36,6 +36,13 @@ module FeatureFlagger
       it 'calls Control#unrelease with appropriated methods' do
         expect(control).to receive(:unrelease).with(resolved_key, subject.id)
         subject.unrelease(key)
+      end
+    end
+
+    describe '#released_count' do
+      it 'calls Control#release_count with appropriated methods' do
+        expect(control).to receive(:release_count).with(resolved_key)
+        subject.released_count(key)
       end
     end
 
@@ -114,6 +121,13 @@ module FeatureFlagger
       it 'calls Control#released_to_all? with appropriated methods' do
         expect(control).to receive(:released_to_all?).with(resolved_key, {})
         DummyClass.released_to_all?(key)
+      end
+    end
+
+    describe '.release_count' do
+      it 'calls Control#release_count with appropriated methods' do
+        expect(control).to receive(:release_count).with(resolved_key)
+        DummyClass.release_count(key)
       end
     end
 

--- a/spec/feature_flagger/storage/redis_spec.rb
+++ b/spec/feature_flagger/storage/redis_spec.rb
@@ -113,6 +113,15 @@ RSpec.describe FeatureFlagger::Storage::Redis do
       end
     end
 
+    describe '#count' do
+      let(:resource_ids) { %w(value1 value2) }
+
+      it 'returns the number of resource_ids for the given feature_key' do
+        storage.add(feature_key, resource_name, resource_ids)
+        expect(storage.count(feature_key)).to eq(2)
+      end
+    end
+
     describe '#feature_keys' do
       it 'returns only feature_keys' do
         storage.add(feature_key, resource_name, resource_id)


### PR DESCRIPTION
This PR adds a new class method for models, allowing the retrieval of the count of resource IDs released for a specific feature key.

Previously, this operation could be performed by calling `Model.all_released_ids_for(:email_marketing, :new_email_flow).size`. However, this method uses `SMEMBERS`, which has a time complexity of O(N), where N is the total number of items in the set, making it possibly slow and aditionally bringing unecessary objects to memory.

This PR introduces a new class method: `Model.released_count(:email_marketing, :new_email_flow)`, which utilizes `SCARD`, a command with O(1) complexity, resulting in a more efficient implementation.

# How to test It

1. Create your own key for a model of your choice.
2. Release the feature for some resource IDs, e.g., `Account.first.release(:my_key)`.
3. Call the method: `Account.released_count(:my_key)` to get the total number of releases.