### PR TITLE
[MKTKERNEL-1552] Fix Yaml.load_file

### DIFF
--- a/lib/feature_flagger/manifest_sources/with_yaml_file.rb
+++ b/lib/feature_flagger/manifest_sources/with_yaml_file.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module FeatureFlagger
   module ManifestSources
     class WithYamlFile

--- a/lib/feature_flagger/manifest_sources/with_yaml_file.rb
+++ b/lib/feature_flagger/manifest_sources/with_yaml_file.rb
@@ -7,7 +7,7 @@ module FeatureFlagger
       end
 
       def resolved_info
-        @resolved_info ||= ::YAML.load_file(@yaml_path) if @yaml_path
+        @resolved_info ||= ::YAML.unsafe_load_file(@yaml_path) if @yaml_path
       end
     end
   end

--- a/lib/feature_flagger/manifest_sources/with_yaml_file.rb
+++ b/lib/feature_flagger/manifest_sources/with_yaml_file.rb
@@ -7,7 +7,7 @@ module FeatureFlagger
       end
 
       def resolved_info
-        @resolved_info ||= ::YAML.unsafe_load_file(@yaml_path) if @yaml_path
+        @resolved_info ||= ::YAML.oad_file(@yaml_path, permitted_classes: [Date]) if @yaml_path
       end
     end
   end

--- a/lib/feature_flagger/manifest_sources/with_yaml_file.rb
+++ b/lib/feature_flagger/manifest_sources/with_yaml_file.rb
@@ -7,7 +7,7 @@ module FeatureFlagger
       end
 
       def resolved_info
-        @resolved_info ||= ::YAML.oad_file(@yaml_path, permitted_classes: [Date]) if @yaml_path
+        @resolved_info ||= ::YAML.load_file(@yaml_path, permitted_classes: [Date]) if @yaml_path
       end
     end
   end


### PR DESCRIPTION
## :memo: Descrição

Ao atualizar o Ruby do CRM para a versão 3.1.6, muitos [testes quebraram](https://app.circleci.com/pipelines/github/ResultadosDigitais/rds-crm/12351/workflows/d6d35122-34ff-47da-a1bb-c47ff451448d/jobs/52136/tests) devido a um erro relacionado ao método **Yaml.load_file**, executado na linha 10 do arquivo lib/feature_flagger/manifest_sources/with_yaml_file.rb:
```
def resolved_info
  @resolved_info ||= ::YAML.load_file(@yaml_path) if @yaml_path
end 
```
Ex de erro:
![Captura de tela de 2024-12-27 10-54-12](https://github.com/user-attachments/assets/9577f3c5-4b9d-4c9e-95eb-8865f24fd4db)

Para a correção, foi necessário alterar o método **load_file** para **unsafe_load_file** (isso porque o stacktrace incia na [gem bootsnap](https://github.com/Shopify/bootsnap/blob/main/CHANGELOG.md#:~:text=LoadPathCache%20on%20TruffleRuby.-,1.16.0,-Use%20RbConfig%3A%3ACONFIG))
